### PR TITLE
remove protobuf from the deps of examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This SDK enables native C++ applications to connect to LiveKit servers for real-
 
 ### For Building the SDK:
 - **Windows:** Visual Studio 2019+, vcpkg
-- **Linux:** `sudo apt install libprotobuf-dev libssl-dev` (protobuf 3.x)
-- **macOS:** `brew install protobuf` (protobuf 3.x)
+- **Linux:** `sudo apt install ninja-build libprotobuf-dev libssl-dev` (protobuf 3.x)
+- **macOS:** `brew install ninja protobuf` (protobuf 3.x)
 
 ### For Using the Pre-built SDK:
 - **Windows:** ✅ All dependencies included (DLLs bundled) - ready to use

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,13 +24,6 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(sdl3)
 
-# Common include directories for examples that need private headers
-# TODO: These should be refactored to use only public headers
-set(EXAMPLES_PRIVATE_INCLUDE_DIRS
-    ${LIVEKIT_ROOT_DIR}/src
-    ${LIVEKIT_BINARY_DIR}/generated
-)
-
 add_executable(SimpleRoom
   simple_room/main.cpp
   simple_room/fallback_capture.cpp
@@ -45,14 +38,10 @@ add_executable(SimpleRoom
   simple_room/wav_audio_source.h
 )
 
-target_include_directories(SimpleRoom PRIVATE ${EXAMPLES_PRIVATE_INCLUDE_DIRS})
 
-# Link protobuf::libprotobuf directly to get proper include directories
-# (livekit links it PRIVATELY so its headers aren't propagated)
 target_link_libraries(SimpleRoom
     PRIVATE
         livekit
-        protobuf::libprotobuf
         SDL3::SDL3
 )
 
@@ -107,7 +96,6 @@ target_link_libraries(SimpleRpc
   PRIVATE
     nlohmann_json::nlohmann_json
     livekit
-    protobuf::libprotobuf
 )
 
 add_executable(SimpleDataStream
@@ -119,7 +107,6 @@ target_include_directories(SimpleDataStream PRIVATE ${EXAMPLES_PRIVATE_INCLUDE_D
 target_link_libraries(SimpleDataStream
   PRIVATE
     livekit
-    protobuf::libprotobuf
 )
 
 add_custom_command(
@@ -135,13 +122,9 @@ if(WIN32)
   # Get the livekit library output directory (where DLLs are copied during main build)
   set(LIVEKIT_LIB_DIR $<TARGET_FILE_DIR:livekit>)
   
-  # Protobuf DLL name depends on configuration (libprotobufd.dll for Debug, libprotobuf.dll for Release)
-  set(PROTOBUF_DLL_NAME $<IF:$<CONFIG:Debug>,libprotobufd.dll,libprotobuf.dll>)
-  
   # List of DLLs to copy (using generator expressions for config-dependent names)
   set(REQUIRED_DLLS
     "livekit_ffi.dll"
-    "${PROTOBUF_DLL_NAME}"
     "abseil_dll.dll"
   )
   


### PR DESCRIPTION
This PR should solve the issues of running the executables in the release zip file, take MacOS one as example:

./bin/SimpleRoom dyld[46441]: Library not loaded: /opt/homebrew/opt/protobuf/lib/libprotobuf.33.2.0.dylib Referenced from: <410C9860-6926-371A-A580-50A366AF5757> /Users/shijing/Downloads/livekit-sdk-macos-arm64-0.1.1/bin/SimpleRoom Reason: tried: '/opt/homebrew/opt/protobuf/lib/libprotobuf.33.2.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/protobuf/lib/libprotobuf.33.2.0.dylib' (no such file), '/opt/homebrew/opt/protobuf/lib/libprotobuf.33.2.0.dylib' (no such file), '/opt/homebrew/Cellar/protobuf/32.1/lib/libprotobuf.33.2.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/protobuf/32.1/lib/libprotobuf.33.2.0.dylib' (no such file), '/opt/homebrew/Cellar/protobuf/32.1/lib/libprotobuf.33.2.0.dylib' (no such file)
