### PR TITLE
Revert "remove protobuf from the deps of examples"

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This SDK enables native C++ applications to connect to LiveKit servers for real-
 
 ### For Building the SDK:
 - **Windows:** Visual Studio 2019+, vcpkg
-- **Linux:** `sudo apt install ninja-build libprotobuf-dev libssl-dev` (protobuf 3.x)
-- **macOS:** `brew install ninja protobuf` (protobuf 3.x)
+- **Linux:** `sudo apt install libprotobuf-dev libssl-dev` (protobuf 3.x)
+- **macOS:** `brew install protobuf` (protobuf 3.x)
 
 ### For Using the Pre-built SDK:
 - **Windows:** ✅ All dependencies included (DLLs bundled) - ready to use

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,6 +24,13 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(sdl3)
 
+# Common include directories for examples that need private headers
+# TODO: These should be refactored to use only public headers
+set(EXAMPLES_PRIVATE_INCLUDE_DIRS
+    ${LIVEKIT_ROOT_DIR}/src
+    ${LIVEKIT_BINARY_DIR}/generated
+)
+
 add_executable(SimpleRoom
   simple_room/main.cpp
   simple_room/fallback_capture.cpp
@@ -38,10 +45,14 @@ add_executable(SimpleRoom
   simple_room/wav_audio_source.h
 )
 
+target_include_directories(SimpleRoom PRIVATE ${EXAMPLES_PRIVATE_INCLUDE_DIRS})
 
+# Link protobuf::libprotobuf directly to get proper include directories
+# (livekit links it PRIVATELY so its headers aren't propagated)
 target_link_libraries(SimpleRoom
     PRIVATE
         livekit
+        protobuf::libprotobuf
         SDL3::SDL3
 )
 
@@ -96,6 +107,7 @@ target_link_libraries(SimpleRpc
   PRIVATE
     nlohmann_json::nlohmann_json
     livekit
+    protobuf::libprotobuf
 )
 
 add_executable(SimpleDataStream
@@ -107,6 +119,7 @@ target_include_directories(SimpleDataStream PRIVATE ${EXAMPLES_PRIVATE_INCLUDE_D
 target_link_libraries(SimpleDataStream
   PRIVATE
     livekit
+    protobuf::libprotobuf
 )
 
 add_custom_command(
@@ -122,9 +135,13 @@ if(WIN32)
   # Get the livekit library output directory (where DLLs are copied during main build)
   set(LIVEKIT_LIB_DIR $<TARGET_FILE_DIR:livekit>)
   
+  # Protobuf DLL name depends on configuration (libprotobufd.dll for Debug, libprotobuf.dll for Release)
+  set(PROTOBUF_DLL_NAME $<IF:$<CONFIG:Debug>,libprotobufd.dll,libprotobuf.dll>)
+  
   # List of DLLs to copy (using generator expressions for config-dependent names)
   set(REQUIRED_DLLS
     "livekit_ffi.dll"
+    "${PROTOBUF_DLL_NAME}"
     "abseil_dll.dll"
   )
   


### PR DESCRIPTION
Reverts livekit/client-sdk-cpp#27

It turns out that linking the protobuf statically will mean that we will be shipping a list of pre-built files, including:
build-release/lib/lib*
-rw-r--r--  1 shijing  staff   816B Jan  7 15:32 build-release/lib/libabsl_bad_any_cast_impl.a
-rw-r--r--  1 shijing  staff   832B Jan  7 15:31 build-release/lib/libabsl_bad_optional_access.a
-rw-r--r--  1 shijing  staff   832B Jan  7 15:31 build-release/lib/libabsl_bad_variant_access.a
-rw-r--r--  1 shijing  staff    15K Jan  7 15:31 build-release/lib/libabsl_base.a
-rw-r--r--  1 shijing  staff   3.4K Jan  7 15:31 build-release/lib/libabsl_city.a
-rw-r--r--  1 shijing  staff    15K Jan  7 15:31 build-release/lib/libabsl_civil_time.a
-rw-r--r--  1 shijing  staff    62K Jan  7 15:31 build-release/lib/libabsl_cord_internal.a
-rw-r--r--  1 shijing  staff    88K Jan  7 15:31 build-release/lib/libabsl_cord.a
-rw-r--r--  1 shijing  staff   1.3K Jan  7 15:31 build-release/lib/libabsl_cordz_functions.a
-rw-r--r--  1 shijing  staff    11K Jan  7 15:31 build-release/lib/libabsl_cordz_handle.a
-rw-r--r--  1 shijing  staff    13K Jan  7 15:31 build-release/lib/libabsl_cordz_info.a
-rw-r--r--  1 shijing  staff   2.8K Jan  7 15:32 build-release/lib/libabsl_cordz_sample_token.a
-rw-r--r--  1 shijing  staff    18K Jan  7 15:31 build-release/lib/libabsl_crc_cord_state.a
-rw-r--r--  1 shijing  staff   992B Jan  7 15:31 build-release/lib/libabsl_crc_cpu_detect.a
-rw-r--r--  1 shijing  staff   103K Jan  7 15:31 build-release/lib/libabsl_crc_internal.a
-rw-r--r--  1 shijing  staff    25K Jan  7 15:31 build-release/lib/libabsl_crc32c.a
-rw-r--r--  1 shijing  staff   1.6K Jan  7 15:31 build-release/lib/libabsl_debugging_internal.a
-rw-r--r--  1 shijing  staff    41K Jan  7 15:31 build-release/lib/libabsl_demangle_internal.a
-rw-r--r--  1 shijing  staff   2.4K Jan  7 15:31 build-release/lib/libabsl_die_if_null.a
-rw-r--r--  1 shijing  staff   4.5K Jan  7 15:31 build-release/lib/libabsl_examine_stack.a
-rw-r--r--  1 shijing  staff   2.1K Jan  7 15:31 build-release/lib/libabsl_exponential_biased.a
-rw-r--r--  1 shijing  staff   8.5K Jan  7 15:32 build-release/lib/libabsl_failure_signal_handler.a
-rw-r--r--  1 shijing  staff   2.1K Jan  7 15:31 build-release/lib/libabsl_flags_commandlineflag_internal.a
-rw-r--r--  1 shijing  staff   2.1K Jan  7 15:31 build-release/lib/libabsl_flags_commandlineflag.a
-rw-r--r--  1 shijing  staff    34K Jan  7 15:31 build-release/lib/libabsl_flags_config.a
-rw-r--r--  1 shijing  staff    34K Jan  7 15:31 build-release/lib/libabsl_flags_internal.a
-rw-r--r--  1 shijing  staff    35K Jan  7 15:31 build-release/lib/libabsl_flags_marshalling.a
-rw-r--r--  1 shijing  staff    76K Jan  7 15:32 build-release/lib/libabsl_flags_parse.a
-rw-r--r--  1 shijing  staff   2.7K Jan  7 15:31 build-release/lib/libabsl_flags_private_handle_accessor.a
-rw-r--r--  1 shijing  staff   6.6K Jan  7 15:31 build-release/lib/libabsl_flags_program_name.a
-rw-r--r--  1 shijing  staff    53K Jan  7 15:31 build-release/lib/libabsl_flags_reflection.a
-rw-r--r--  1 shijing  staff    71K Jan  7 15:32 build-release/lib/libabsl_flags_usage_internal.a
-rw-r--r--  1 shijing  staff   5.5K Jan  7 15:32 build-release/lib/libabsl_flags_usage.a
-rw-r--r--  1 shijing  staff    22K Jan  7 15:31 build-release/lib/libabsl_graphcycles_internal.a
-rw-r--r--  1 shijing  staff   3.1K Jan  7 15:31 build-release/lib/libabsl_hash.a
-rw-r--r--  1 shijing  staff    15K Jan  7 15:31 build-release/lib/libabsl_hashtablez_sampler.a
-rw-r--r--  1 shijing  staff    14K Jan  7 15:31 build-release/lib/libabsl_int128.a
-rw-r--r--  1 shijing  staff   6.8K Jan  7 15:31 build-release/lib/libabsl_kernel_timeout_internal.a
-rw-r--r--  1 shijing  staff   2.0K Jan  7 15:31 build-release/lib/libabsl_leak_check.a
-rw-r--r--  1 shijing  staff   800B Jan  7 15:31 build-release/lib/libabsl_log_entry.a
-rw-r--r--  1 shijing  staff    17K Jan  7 15:32 build-release/lib/libabsl_log_flags.a
-rw-r--r--  1 shijing  staff    13K Jan  7 15:31 build-release/lib/libabsl_log_globals.a
-rw-r--r--  1 shijing  staff   1.0K Jan  7 15:31 build-release/lib/libabsl_log_initialize.a
-rw-r--r--  1 shijing  staff    30K Jan  7 15:31 build-release/lib/libabsl_log_internal_check_op.a
-rw-r--r--  1 shijing  staff   1.8K Jan  7 15:31 build-release/lib/libabsl_log_internal_conditions.a
-rw-r--r--  1 shijing  staff   1.5K Jan  7 15:31 build-release/lib/libabsl_log_internal_fnmatch.a
-rw-r--r--  1 shijing  staff   6.3K Jan  7 15:31 build-release/lib/libabsl_log_internal_format.a
-rw-r--r--  1 shijing  staff   5.2K Jan  7 15:31 build-release/lib/libabsl_log_internal_globals.a
-rw-r--r--  1 shijing  staff    16K Jan  7 15:31 build-release/lib/libabsl_log_internal_log_sink_set.a
-rw-r--r--  1 shijing  staff    41K Jan  7 15:31 build-release/lib/libabsl_log_internal_message.a
-rw-r--r--  1 shijing  staff   1.0K Jan  7 15:31 build-release/lib/libabsl_log_internal_nullguard.a
-rw-r--r--  1 shijing  staff   4.6K Jan  7 15:31 build-release/lib/libabsl_log_internal_proto.a
-rw-r--r--  1 shijing  staff   6.7K Jan  7 15:31 build-release/lib/libabsl_log_severity.a
-rw-r--r--  1 shijing  staff   1.9K Jan  7 15:31 build-release/lib/libabsl_log_sink.a
-rw-r--r--  1 shijing  staff   1.2K Jan  7 15:31 build-release/lib/libabsl_low_level_hash.a
-rw-r--r--  1 shijing  staff    21K Jan  7 15:31 build-release/lib/libabsl_malloc_internal.a
-rw-r--r--  1 shijing  staff   2.9K Jan  7 15:32 build-release/lib/libabsl_periodic_sampler.a
-rw-r--r--  1 shijing  staff   8.0K Jan  7 15:32 build-release/lib/libabsl_random_distributions.a
-rw-r--r--  1 shijing  staff    16K Jan  7 15:32 build-release/lib/libabsl_random_internal_distribution_test_util.a
-rw-r--r--  1 shijing  staff   5.1K Jan  7 15:32 build-release/lib/libabsl_random_internal_platform.a
-rw-r--r--  1 shijing  staff    17K Jan  7 15:32 build-release/lib/libabsl_random_internal_pool_urbg.a
-rw-r--r--  1 shijing  staff   2.3K Jan  7 15:32 build-release/lib/libabsl_random_internal_randen_hwaes_impl.a
-rw-r--r--  1 shijing  staff   832B Jan  7 15:32 build-release/lib/libabsl_random_internal_randen_hwaes.a
-rw-r--r--  1 shijing  staff   7.1K Jan  7 15:32 build-release/lib/libabsl_random_internal_randen_slow.a
-rw-r--r--  1 shijing  staff   2.1K Jan  7 15:32 build-release/lib/libabsl_random_internal_randen.a
-rw-r--r--  1 shijing  staff   3.6K Jan  7 15:32 build-release/lib/libabsl_random_internal_seed_material.a
-rw-r--r--  1 shijing  staff   2.7K Jan  7 15:32 build-release/lib/libabsl_random_seed_gen_exception.a
-rw-r--r--  1 shijing  staff   3.6K Jan  7 15:32 build-release/lib/libabsl_random_seed_sequences.a
-rw-r--r--  1 shijing  staff   7.3K Jan  7 15:31 build-release/lib/libabsl_raw_hash_set.a
-rw-r--r--  1 shijing  staff   5.8K Jan  7 15:31 build-release/lib/libabsl_raw_logging_internal.a
-rw-r--r--  1 shijing  staff   4.0K Jan  7 15:32 build-release/lib/libabsl_scoped_set_env.a
-rw-r--r--  1 shijing  staff   2.7K Jan  7 15:31 build-release/lib/libabsl_spinlock_wait.a
-rw-r--r--  1 shijing  staff   6.1K Jan  7 15:31 build-release/lib/libabsl_stacktrace.a
-rw-r--r--  1 shijing  staff    46K Jan  7 15:31 build-release/lib/libabsl_status.a
-rw-r--r--  1 shijing  staff    12K Jan  7 15:31 build-release/lib/libabsl_statusor.a
-rw-r--r--  1 shijing  staff   120K Jan  7 15:31 build-release/lib/libabsl_str_format_internal.a
-rw-r--r--  1 shijing  staff   4.9K Jan  7 15:31 build-release/lib/libabsl_strerror.a
-rw-r--r--  1 shijing  staff   808B Jan  7 15:31 build-release/lib/libabsl_string_view.a
-rw-r--r--  1 shijing  staff   7.5K Jan  7 15:31 build-release/lib/libabsl_strings_internal.a
-rw-r--r--  1 shijing  staff   155K Jan  7 15:31 build-release/lib/libabsl_strings.a
-rw-r--r--  1 shijing  staff   4.9K Jan  7 15:31 build-release/lib/libabsl_symbolize.a
-rw-r--r--  1 shijing  staff    79K Jan  7 15:31 build-release/lib/libabsl_synchronization.a
-rw-r--r--  1 shijing  staff    17K Jan  7 15:31 build-release/lib/libabsl_throw_delegate.a
-rw-r--r--  1 shijing  staff   164K Jan  7 15:31 build-release/lib/libabsl_time_zone.a
-rw-r--r--  1 shijing  staff    82K Jan  7 15:31 build-release/lib/libabsl_time.a
-rw-r--r--  1 shijing  staff    23K Jan  7 15:31 build-release/lib/libabsl_vlog_config_internal.a
-rwxr-xr-x  1 shijing  staff    30M Jan  7 15:34 build-release/lib/liblivekit_ffi.dylib
-rw-r--r--  1 shijing  staff   4.6M Jan  7 15:34 build-release/lib/liblivekit.a
-rw-r--r--  1 shijing  staff   781K Jan  7 15:32 build-release/lib/libprotobuf-lite.a
-rw-r--r--  1 shijing  staff   4.8M Jan  7 15:31 build-release/lib/libprotobuf.a
-rw-r--r--  1 shijing  staff    10M Jan  7 15:32 build-release/lib/libprotoc.a
-rw-r--r--  1 shijing  staff   2.9K Jan  7 15:32 build-release/lib/libutf8_range.a
-rw-r--r--  1 shijing  staff   2.7K Jan  7 15:31 build-release/lib/libutf8_validity.a

So I am reverting the approach back to rely on our developers to pull in protobuf and absl