### PR TITLE
Support for compile_commands.json/clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  CompilationDatabase: .

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ lib/
 *.exe
 livekit.log
 web/
+compile_commands.json

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,7 +38,8 @@
       "hidden": true,
       "generator": "Ninja",
       "cacheVariables": {
-        "LIVEKIT_USE_VCPKG": "OFF"
+        "LIVEKIT_USE_VCPKG": "OFF",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       },
       "condition": {
         "type": "equals",
@@ -51,7 +52,8 @@
       "hidden": true,
       "generator": "Ninja",
       "cacheVariables": {
-        "LIVEKIT_USE_VCPKG": "OFF"
+        "LIVEKIT_USE_VCPKG": "OFF",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       },
       "condition": {
         "type": "equals",

--- a/build.sh
+++ b/build.sh
@@ -152,6 +152,11 @@ configure() {
       cmake -S . -B "${BUILD_DIR}" -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
     fi
   fi
+
+  if [[ -f "${BUILD_DIR}/compile_commands.json" ]]; then
+    ln -sf "${BUILD_DIR}/compile_commands.json" "${PROJECT_ROOT}/compile_commands.json"
+    echo "==> Symlinked compile_commands.json -> ${BUILD_DIR}/compile_commands.json"
+  fi
 }
 
 build() {


### PR DESCRIPTION
This PR adds support for `compile_commands.json` (Mac/Linux). This is implemented using CMake's built-in feature, but additionally the build script symlinks the file to the root of the directory (but is `.gitignore`'d). 

This enables a few features:
- Intellisense autocomplete via VSCode/Cursor extension `llvm-vs-code-extensions.vscode-clangd`
- `clang-tidy` support in a future PR for static analysis checks on the repository

