### PR TITLE
fix the RPC tests

### DIFF
--- a/src/tests/integration/test_media_multistream.cpp
+++ b/src/tests/integration/test_media_multistream.cpp
@@ -231,10 +231,16 @@ void MediaMultiStreamIntegrationTest::runPublishTwoVideoAndTwoAudioTracks(
   }
 
   for (const auto &track : video_tracks) {
-    sender_room->localParticipant()->unpublishTrack(track->sid());
+    if (track->publication()) {
+      sender_room->localParticipant()->unpublishTrack(
+          track->publication()->sid());
+    }
   }
   for (const auto &track : audio_tracks) {
-    sender_room->localParticipant()->unpublishTrack(track->sid());
+    if (track->publication()) {
+      sender_room->localParticipant()->unpublishTrack(
+          track->publication()->sid());
+    }
   }
 }
 

--- a/src/tests/stress/test_latency_measurement.cpp
+++ b/src/tests/stress/test_latency_measurement.cpp
@@ -294,8 +294,19 @@ TEST_F(LatencyMeasurementTest, ConnectionTime) {
       double latency_ms =
           std::chrono::duration<double, std::milli>(end - start).count();
       stats.addMeasurement(latency_ms);
+
+      // Get room and participant session IDs for debugging
+      auto room_info = room->room_info();
+      std::string room_sid =
+          room_info.sid.has_value() ? room_info.sid.value() : "unknown";
+      std::string participant_sid = room->localParticipant()
+                                        ? room->localParticipant()->sid()
+                                        : "unknown";
+
       std::cout << "  Iteration " << (i + 1) << ": " << std::fixed
-                << std::setprecision(2) << latency_ms << " ms" << std::endl;
+                << std::setprecision(2) << latency_ms << " ms"
+                << " | participant_sid=" << participant_sid
+                << " | room_sid=" << room_sid << std::endl;
 
     } else {
       std::cout << "  Iteration " << (i + 1) << ": FAILED to connect"
@@ -841,8 +852,12 @@ TEST_F(LatencyMeasurementTest, FullDeplexAudioLatency) {
     std::cout << "Response timeouts: " << timeouts << std::endl;
   }
 
-  room_a->localParticipant()->unpublishTrack(track_a->sid());
-  room_b->localParticipant()->unpublishTrack(track_b->sid());
+  if (track_a->publication()) {
+    room_a->localParticipant()->unpublishTrack(track_a->publication()->sid());
+  }
+  if (track_b->publication()) {
+    room_b->localParticipant()->unpublishTrack(track_b->publication()->sid());
+  }
 
   EXPECT_GT(round_trip_stats.count(), 0)
       << "At least one round-trip latency measurement should be recorded";


### PR DESCRIPTION
Problem:
 When a local track is created, its sid() returns "TR_unknown"                                                                                                                                                   
  - The real track SID is assigned by the server during publishing and stored in the publication, not the track itself                                                                                                                                                
  - The test uses track->sid() which returns "TR_unknown", causing "track not found" error                                                                                                                                                                            
                                                                                                                                                                                                                                                                      
  The Fix:                                                                                                                                                                                                                                                            
  The test should use track->publication()->sid() instead of track->sid() when unpublishing, like the other working code does 