### PR TITLE
fix: correct catch ordering and migrate to spdlog

### DIFF
--- a/bridge/CMakeLists.txt
+++ b/bridge/CMakeLists.txt
@@ -32,6 +32,13 @@ target_include_directories(livekit_bridge
 target_link_libraries(livekit_bridge
   PUBLIC
     livekit
+  PRIVATE
+    spdlog::spdlog
+)
+
+target_compile_definitions(livekit_bridge
+  PRIVATE
+    SPDLOG_ACTIVE_LEVEL=${_SPDLOG_ACTIVE_LEVEL}
 )
 
 if(MSVC)

--- a/bridge/src/bridge_audio_track.cpp
+++ b/bridge/src/bridge_audio_track.cpp
@@ -24,7 +24,8 @@
 #include "livekit/local_audio_track.h"
 #include "livekit/local_participant.h"
 
-#include <iostream>
+#include "lk_log.h"
+
 #include <stdexcept>
 
 namespace livekit_bridge {
@@ -55,7 +56,7 @@ bool BridgeAudioTrack::pushFrame(const std::vector<std::int16_t> &data,
   try {
     source_->captureFrame(frame, timeout_ms);
   } catch (const std::exception &e) {
-    std::cerr << "[error] BridgeAudioTrack captureFrame error: " << e.what() << "\n";
+    LK_LOG_ERROR("BridgeAudioTrack captureFrame error: {}", e.what());
     return false;
   }
   return true;
@@ -76,7 +77,7 @@ bool BridgeAudioTrack::pushFrame(const std::int16_t *data,
   try {
     source_->captureFrame(frame, timeout_ms);
   } catch (const std::exception &e) {
-    std::cerr << "[error] BridgeAudioTrack captureFrame error: " << e.what() << "\n";
+    LK_LOG_ERROR("BridgeAudioTrack captureFrame error: {}", e.what());
     return false;
   }
   return true;
@@ -114,8 +115,8 @@ void BridgeAudioTrack::release() {
       participant_->unpublishTrack(track_->publication()->sid());
     } catch (...) {
       // Best-effort cleanup; ignore errors during teardown
-      std::cerr << "[warn] BridgeAudioTrack unpublishTrack error, continuing "
-                   "with cleanup\n";
+      LK_LOG_WARN("BridgeAudioTrack unpublishTrack error, continuing "
+                  "with cleanup");
     }
   }
 

--- a/bridge/src/bridge_video_track.cpp
+++ b/bridge/src/bridge_video_track.cpp
@@ -24,7 +24,8 @@
 #include "livekit/video_frame.h"
 #include "livekit/video_source.h"
 
-#include <iostream>
+#include "lk_log.h"
+
 #include <stdexcept>
 
 namespace livekit_bridge {
@@ -55,7 +56,7 @@ bool BridgeVideoTrack::pushFrame(const std::vector<std::uint8_t> &rgba,
   try {
     source_->captureFrame(frame, timestamp_us);
   } catch (const std::exception &e) {
-    std::cerr << "[error] BridgeVideoTrack captureFrame error: " << e.what() << "\n";
+    LK_LOG_ERROR("BridgeVideoTrack captureFrame error: {}", e.what());
     return false;
   }
   return true;
@@ -75,7 +76,7 @@ bool BridgeVideoTrack::pushFrame(const std::uint8_t *rgba,
   try {
     source_->captureFrame(frame, timestamp_us);
   } catch (const std::exception &e) {
-    std::cerr << "[error] BridgeVideoTrack captureFrame error: " << e.what() << "\n";
+    LK_LOG_ERROR("BridgeVideoTrack captureFrame error: {}", e.what());
     return false;
   }
   return true;
@@ -113,8 +114,8 @@ void BridgeVideoTrack::release() {
       participant_->unpublishTrack(track_->publication()->sid());
     } catch (...) {
       // Best-effort cleanup; ignore errors during teardown
-      std::cerr << "[warn] BridgeVideoTrack unpublishTrack error, continuing "
-                   "with cleanup\n";
+      LK_LOG_WARN("BridgeVideoTrack unpublishTrack error, continuing "
+                  "with cleanup");
     }
   }
 

--- a/bridge/src/livekit_bridge.cpp
+++ b/bridge/src/livekit_bridge.cpp
@@ -33,8 +33,10 @@
 #include "livekit/video_frame.h"
 #include "livekit/video_source.h"
 
+#include "livekit/rpc_error.h"
+#include "lk_log.h"
+
 #include <cassert>
-#include <iostream>
 #include <stdexcept>
 
 namespace livekit_bridge {
@@ -123,8 +125,8 @@ void LiveKitBridge::disconnect() {
     std::lock_guard<std::mutex> lock(mutex_);
 
     if (!connected_) {
-      std::cerr << "[warn] Attempting to disconnect an already disconnected "
-                   "bridge. Things may not disconnect properly.\n";
+      LK_LOG_WARN("Attempting to disconnect an already disconnected "
+                  "bridge. Things may not disconnect properly.");
     }
 
     connected_ = false;
@@ -242,8 +244,8 @@ void LiveKitBridge::setOnAudioFrameCallback(
     AudioFrameCallback callback) {
   std::lock_guard<std::mutex> lock(mutex_);
   if (!room_) {
-    std::cerr << "[warn] setOnAudioFrameCallback called before connect(); "
-                 "ignored\n";
+    LK_LOG_WARN("setOnAudioFrameCallback called before connect(); "
+                "ignored");
     return;
   }
   room_->setOnAudioFrameCallback(participant_identity, source,
@@ -255,8 +257,8 @@ void LiveKitBridge::setOnVideoFrameCallback(
     VideoFrameCallback callback) {
   std::lock_guard<std::mutex> lock(mutex_);
   if (!room_) {
-    std::cerr << "[warn] setOnVideoFrameCallback called before connect(); "
-                 "ignored\n";
+    LK_LOG_WARN("setOnVideoFrameCallback called before connect(); "
+                "ignored");
     return;
   }
   room_->setOnVideoFrameCallback(participant_identity, source,
@@ -297,14 +299,11 @@ LiveKitBridge::performRpc(const std::string &destination_identity,
   try {
     return rpc_controller_->performRpc(destination_identity, method, payload,
                                        response_timeout);
-  } catch (const std::exception &e) {
-    std::cerr << "[LiveKitBridge] Exception: " << e.what() << "\n";
-    return std::nullopt;
-  } catch (const std::runtime_error &e) {
-    std::cerr << "[LiveKitBridge] Runtime error: " << e.what() << "\n";
-    return std::nullopt;
   } catch (const livekit::RpcError &e) {
-    std::cerr << "[LiveKitBridge] RPC error: " << e.what() << "\n";
+    LK_LOG_ERROR("performRpc RPC error (code {}): {}", e.code(), e.message());
+    return std::nullopt;
+  } catch (const std::exception &e) {
+    LK_LOG_ERROR("performRpc exception: {}", e.what());
     return std::nullopt;
   }
 }
@@ -319,14 +318,11 @@ bool LiveKitBridge::registerRpcMethod(
   try {
     rpc_controller_->registerRpcMethod(method_name, std::move(handler));
     return true;
-  } catch (const std::exception &e) {
-    std::cerr << "[LiveKitBridge] Exception: " << e.what() << "\n";
-    return false;
-  } catch (const std::runtime_error &e) {
-    std::cerr << "[LiveKitBridge] Runtime error: " << e.what() << "\n";
-    return false;
   } catch (const livekit::RpcError &e) {
-    std::cerr << "[LiveKitBridge] RPC error: " << e.what() << "\n";
+    LK_LOG_ERROR("registerRpcMethod RPC error (code {}): {}", e.code(), e.message());
+    return false;
+  } catch (const std::exception &e) {
+    LK_LOG_ERROR("registerRpcMethod exception: {}", e.what());
     return false;
   }
 }
@@ -338,14 +334,11 @@ bool LiveKitBridge::unregisterRpcMethod(const std::string &method_name) {
   try {
     rpc_controller_->unregisterRpcMethod(method_name);
     return true;
-  } catch (const std::exception &e) {
-    std::cerr << "[LiveKitBridge] Exception: " << e.what() << "\n";
-    return false;
-  } catch (const std::runtime_error &e) {
-    std::cerr << "[LiveKitBridge] Runtime error: " << e.what() << "\n";
-    return false;
   } catch (const livekit::RpcError &e) {
-    std::cerr << "[LiveKitBridge] RPC error: " << e.what() << "\n";
+    LK_LOG_ERROR("unregisterRpcMethod RPC error (code {}): {}", e.code(), e.message());
+    return false;
+  } catch (const std::exception &e) {
+    LK_LOG_ERROR("unregisterRpcMethod exception: {}", e.what());
     return false;
   }
 }
@@ -358,14 +351,11 @@ bool LiveKitBridge::requestRemoteTrackMute(
   try {
     rpc_controller_->requestRemoteTrackMute(destination_identity, track_name);
     return true;
-  } catch (const std::exception &e) {
-    std::cerr << "[LiveKitBridge] Exception: " << e.what() << "\n";
-    return false;
-  } catch (const std::runtime_error &e) {
-    std::cerr << "[LiveKitBridge] Runtime error: " << e.what() << "\n";
-    return false;
   } catch (const livekit::RpcError &e) {
-    std::cerr << "[LiveKitBridge] RPC error: " << e.what() << "\n";
+    LK_LOG_ERROR("requestRemoteTrackMute RPC error (code {}): {}", e.code(), e.message());
+    return false;
+  } catch (const std::exception &e) {
+    LK_LOG_ERROR("requestRemoteTrackMute exception: {}", e.what());
     return false;
   }
 }
@@ -378,14 +368,11 @@ bool LiveKitBridge::requestRemoteTrackUnmute(
   try {
     rpc_controller_->requestRemoteTrackUnmute(destination_identity, track_name);
     return true;
-  } catch (const std::exception &e) {
-    std::cerr << "[LiveKitBridge] Exception: " << e.what() << "\n";
-    return false;
-  } catch (const std::runtime_error &e) {
-    std::cerr << "[LiveKitBridge] Runtime error: " << e.what() << "\n";
-    return false;
   } catch (const livekit::RpcError &e) {
-    std::cerr << "[LiveKitBridge] RPC error: " << e.what() << "\n";
+    LK_LOG_ERROR("requestRemoteTrackUnmute RPC error (code {}): {}", e.code(), e.message());
+    return false;
+  } catch (const std::exception &e) {
+    LK_LOG_ERROR("requestRemoteTrackUnmute exception: {}", e.what());
     return false;
   }
 }

--- a/src/track_proto_converter.h
+++ b/src/track_proto_converter.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#pragma once
+
 #include "livekit/participant.h"
 #include "livekit/track.h"
 #include "livekit/track_publication.h"


### PR DESCRIPTION

- RpcError catches now log code() and message() instead of just what(), preserving the structured error information (error code, message, data).

- Replace all std::cerr usage across bridge/ with LK_LOG_ERROR and LK_LOG_WARN macros (spdlog), consistent with the rest of the SDK. Remove <iostream> includes that are no longer needed.

- Add missing #pragma once include guard to src/track_proto_converter.h, which had no include guard at all (every other header in the project has one).