### PR TITLE
Minor fix change to copy semantics for const shared_ptr since it has …

### DIFF
--- a/include/livekit/local_audio_track.h
+++ b/include/livekit/local_audio_track.h
@@ -85,9 +85,12 @@ public:
   }
 
   /// Sets the publication that owns this track.
+  /// Note: std::move on a const& silently falls back to a copy, so we assign
+  /// directly. Changing the virtual signature to take by value would enable
+  /// a true move but is an API-breaking change left for a future revision.
   void setPublication(const std::shared_ptr<LocalTrackPublication>
                           &publication) noexcept override {
-    local_publication_ = std::move(publication);
+    local_publication_ = publication;
   }
 
 private:

--- a/include/livekit/local_video_track.h
+++ b/include/livekit/local_video_track.h
@@ -86,9 +86,12 @@ public:
   }
 
   /// Sets the publication that owns this track.
+  /// Note: std::move on a const& silently falls back to a copy, so we assign
+  /// directly. Changing the virtual signature to take by value would enable
+  /// a true move but is a API-breaking change hence left for a future revision.
   void setPublication(const std::shared_ptr<LocalTrackPublication>
                           &publication) noexcept override {
-    local_publication_ = std::move(publication);
+    local_publication_ = publication;
   }
 
 private:


### PR DESCRIPTION
### Summary

LocalAudioTrack::setPublication() and LocalVideoTrack::setPublication() both called std::move() on a const shared_ptr<LocalTrackPublication>& parameter. 
Because the parameter is const, std::move produces a const shared_ptr&&, which cannot bind to shared_ptr's 
move-assignment operator (which requires non-const &&). 
The compiler silently falls back to copy assignment — the std::move was a no-op.

This PR removes the std::move and documents why the virtual signature is left as const& rather than changed to 
by-value (which would enable a true move but constitutes an API-breaking change).

### What changed
local_audio_track.h — Replace std::move(publication) with direct copy assignment
local_video_track.h — Same fix
Added comments explaining the const& constraint from the base Track::setPublication virtual signature

### Why not change the signature?
setPublication is declared virtual in Track. Changing the parameter from const shared_ptr& to shared_ptr (by value) would be an ABI/API break for any downstream code overriding this method. 

### Impact
No behavioral change — the code was already copying. This just removes a misleading std::move that suggests a move is happening when it isn't.