### PR TITLE
Clang-tidy: additional checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 Checks: >
   -*,
   bugprone-*,
+  misc-const-correctness,
   performance-*,
   modernize-*,
   readability-misleading-indentation,

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -599,7 +599,7 @@ jobs:
           tidy-checks: ''
           database: build-release
           files-changed-only: false
-          lines-changed-only: true
+          lines-changed-only: false
           extensions: 'c,cpp,cc,cxx'
           ignore: 'build-*|cpp-example-collection|client-sdk-rust|vcpkg_installed|src/tests|bridge|src/room_event_converter.cpp'
           file-annotations: true

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -599,7 +599,7 @@ jobs:
           tidy-checks: ''
           database: build-release
           files-changed-only: false
-          lines-changed-only: false
+          lines-changed-only: true
           extensions: 'c,cpp,cc,cxx'
           ignore: 'build-*|cpp-example-collection|client-sdk-rust|vcpkg_installed|src/tests|bridge|src/room_event_converter.cpp'
           file-annotations: true

--- a/src/audio_frame.cpp
+++ b/src/audio_frame.cpp
@@ -83,7 +83,7 @@ AudioFrame::fromOwnedInfo(const proto::OwnedAudioFrameBuffer &owned) {
   }
 
   {
-    FfiHandle guard(static_cast<uintptr_t>(owned.handle().id()));
+    const FfiHandle guard(static_cast<uintptr_t>(owned.handle().id()));
     // guard is destroyed at end of scope, which should call into the FFI to
     // drop the OwnedAudioFrameBuffer.
   }

--- a/src/audio_processing_module.cpp
+++ b/src/audio_processing_module.cpp
@@ -35,7 +35,7 @@ AudioProcessingModule::AudioProcessingModule(const Options &options) {
   msg->set_high_pass_filter_enabled(options.high_pass_filter);
   msg->set_gain_controller_enabled(options.auto_gain_control);
 
-  proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
+  const proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
 
   if (!resp.has_new_apm()) {
     throw std::runtime_error(
@@ -69,7 +69,7 @@ void AudioProcessingModule::processStream(AudioFrame &frame) {
   msg->set_sample_rate(static_cast<std::uint32_t>(frame.sample_rate()));
   msg->set_num_channels(static_cast<std::uint32_t>(frame.num_channels()));
 
-  proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
+  const proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
 
   if (!resp.has_apm_process_stream()) {
     throw std::runtime_error(
@@ -101,7 +101,7 @@ void AudioProcessingModule::processReverseStream(AudioFrame &frame) {
   msg->set_sample_rate(static_cast<std::uint32_t>(frame.sample_rate()));
   msg->set_num_channels(static_cast<std::uint32_t>(frame.num_channels()));
 
-  proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
+  const proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
 
   if (!resp.has_apm_process_reverse_stream()) {
     throw std::runtime_error(
@@ -125,7 +125,7 @@ void AudioProcessingModule::setStreamDelayMs(int delay_ms) {
   msg->set_apm_handle(static_cast<std::uint64_t>(handle_.get()));
   msg->set_delay_ms(delay_ms);
 
-  proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
+  const proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
 
   if (!resp.has_apm_set_stream_delay()) {
     throw std::runtime_error(

--- a/src/audio_source.cpp
+++ b/src/audio_source.cpp
@@ -50,7 +50,7 @@ AudioSource::AudioSource(int sample_rate, int num_channels, int queue_size_ms)
   msg->set_num_channels(static_cast<std::uint32_t>(num_channels_));
   msg->set_queue_size_ms(static_cast<std::uint32_t>(queue_size_ms_));
 
-  proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
+  const proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
 
   const auto &source_info = resp.new_audio_source().source();
   // Wrap FFI handle in RAII FfiHandle
@@ -62,9 +62,9 @@ double AudioSource::queuedDuration() const noexcept {
     return 0.0;
   }
 
-  double now = now_seconds();
-  double elapsed = now - last_capture_;
-  double remaining = q_size_ - elapsed;
+  const double now = now_seconds();
+  const double elapsed = now - last_capture_;
+  const double remaining = q_size_ - elapsed;
   return remaining > 0.0 ? remaining : 0.0;
 }
 
@@ -100,9 +100,9 @@ void AudioSource::captureFrame(const AudioFrame &frame, int timeout_ms) {
   }
 
   // Queue tracking, same logic as before
-  double now = now_seconds();
-  double elapsed = (last_capture_ == 0.0) ? 0.0 : (now - last_capture_);
-  double frame_duration = static_cast<double>(frame.samples_per_channel()) /
+  const double now = now_seconds();
+  const double elapsed = (last_capture_ == 0.0) ? 0.0 : (now - last_capture_);
+  const double frame_duration = static_cast<double>(frame.samples_per_channel()) /
                           static_cast<double>(sample_rate_);
   q_size_ += frame_duration - elapsed;
   if (q_size_ < 0.0) {
@@ -111,7 +111,7 @@ void AudioSource::captureFrame(const AudioFrame &frame, int timeout_ms) {
   last_capture_ = now;
 
   // Build AudioFrameBufferInfo from the wrapper
-  proto::AudioFrameBufferInfo buf = frame.toProto();
+  const proto::AudioFrameBufferInfo buf = frame.toProto();
   // Use async FFI API and block until the callback completes
   auto fut = FfiClient::instance().captureAudioFrameAsync(handle_.get(), buf);
   if (timeout_ms == 0) {

--- a/src/ffi_client.cpp
+++ b/src/ffi_client.cpp
@@ -501,7 +501,7 @@ FfiClient::publishTrackAsync(std::uint64_t local_participant_handle,
           return;
         }
 
-        const proto::OwnedTrackPublication pub = cb.publication();
+        const proto::OwnedTrackPublication &pub = cb.publication();
         pr.set_value(std::move(pub));
       });
 

--- a/src/ffi_client.cpp
+++ b/src/ffi_client.cpp
@@ -200,7 +200,7 @@ FfiClient::sendRequest(const proto::FfiRequest &request) const {
   }
 
   // Ensure we drop the handle exactly once on all paths
-  FfiHandle handle_guard(static_cast<uintptr_t>(handle));
+  const FfiHandle handle_guard(static_cast<uintptr_t>(handle));
   if (!resp_ptr || resp_len == 0) {
     throw std::runtime_error("FFI returned empty response bytes");
   }
@@ -403,7 +403,7 @@ FfiClient::connectAsync(const std::string &url, const std::string &token,
   }
 
   try {
-    proto::FfiResponse resp = sendRequest(req);
+    const proto::FfiResponse resp = sendRequest(req);
     if (!resp.has_connect()) {
       logAndThrow("FfiResponse missing connect");
     }
@@ -501,7 +501,7 @@ FfiClient::publishTrackAsync(std::uint64_t local_participant_handle,
           return;
         }
 
-        proto::OwnedTrackPublication pub = cb.publication();
+        const proto::OwnedTrackPublication pub = cb.publication();
         pr.set_value(std::move(pub));
       });
 
@@ -515,7 +515,7 @@ FfiClient::publishTrackAsync(std::uint64_t local_participant_handle,
   msg->mutable_options()->CopyFrom(optionProto);
 
   try {
-    proto::FfiResponse resp = sendRequest(req);
+    const proto::FfiResponse resp = sendRequest(req);
     if (!resp.has_publish_track()) {
       logAndThrow("FfiResponse missing publish_track");
     }
@@ -560,7 +560,7 @@ FfiClient::unpublishTrackAsync(std::uint64_t local_participant_handle,
   msg->set_request_async_id(async_id);
 
   try {
-    proto::FfiResponse resp = sendRequest(req);
+    const proto::FfiResponse resp = sendRequest(req);
     if (!resp.has_unpublish_track()) {
       logAndThrow("FfiResponse missing unpublish_track");
     }
@@ -611,7 +611,7 @@ std::future<void> FfiClient::publishDataAsync(
   }
 
   try {
-    proto::FfiResponse resp = sendRequest(req);
+    const proto::FfiResponse resp = sendRequest(req);
     if (!resp.has_publish_data()) {
       logAndThrow("FfiResponse missing publish_data");
     }
@@ -665,7 +665,7 @@ FfiClient::publishDataTrackAsync(std::uint64_t local_participant_handle,
   msg->set_request_async_id(async_id);
 
   try {
-    proto::FfiResponse resp = sendRequest(req);
+    const proto::FfiResponse resp = sendRequest(req);
     if (!resp.has_publish_data_track()) {
       cancelPendingByAsyncId(async_id);
       std::promise<Result<proto::OwnedLocalDataTrack, PublishDataTrackError>>
@@ -760,7 +760,7 @@ std::future<void> FfiClient::publishSipDtmfAsync(
   }
 
   try {
-    proto::FfiResponse resp = sendRequest(req);
+    const proto::FfiResponse resp = sendRequest(req);
     if (!resp.has_publish_sip_dtmf()) {
       logAndThrow("FfiResponse missing publish_sip_dtmf");
     }
@@ -803,7 +803,7 @@ FfiClient::setLocalMetadataAsync(std::uint64_t local_participant_handle,
   msg->set_request_async_id(async_id);
 
   try {
-    proto::FfiResponse resp = sendRequest(req);
+    const proto::FfiResponse resp = sendRequest(req);
     if (!resp.has_set_local_metadata()) {
       logAndThrow("FfiResponse missing set_local_metadata");
     }
@@ -848,7 +848,7 @@ FfiClient::captureAudioFrameAsync(std::uint64_t source_handle,
   msg->mutable_buffer()->CopyFrom(buffer);
 
   try {
-    proto::FfiResponse resp = sendRequest(req);
+    const proto::FfiResponse resp = sendRequest(req);
     if (!resp.has_capture_audio_frame()) {
       logAndThrow("FfiResponse missing capture_audio_frame");
     }
@@ -902,7 +902,7 @@ FfiClient::performRpcAsync(std::uint64_t local_participant_handle,
   }
 
   try {
-    proto::FfiResponse resp = sendRequest(req);
+    const proto::FfiResponse resp = sendRequest(req);
     if (!resp.has_perform_rpc()) {
       logAndThrow("FfiResponse missing perform_rpc");
     }
@@ -951,7 +951,7 @@ std::future<void> FfiClient::sendStreamHeaderAsync(
   }
 
   try {
-    proto::FfiResponse resp = sendRequest(req);
+    const proto::FfiResponse resp = sendRequest(req);
     if (!resp.has_send_stream_header()) {
       logAndThrow("FfiResponse missing send_stream_header");
     }
@@ -1000,7 +1000,7 @@ std::future<void> FfiClient::sendStreamChunkAsync(
   }
 
   try {
-    proto::FfiResponse resp = sendRequest(req);
+    const proto::FfiResponse resp = sendRequest(req);
     if (!resp.has_send_stream_chunk()) {
       logAndThrow("FfiResponse missing send_stream_chunk");
     }
@@ -1045,7 +1045,7 @@ FfiClient::sendStreamTrailerAsync(std::uint64_t local_participant_handle,
   msg->set_request_async_id(async_id);
 
   try {
-    proto::FfiResponse resp = sendRequest(req);
+    const proto::FfiResponse resp = sendRequest(req);
     if (!resp.has_send_stream_trailer()) {
       logAndThrow("FfiResponse missing send_stream_trailer");
     }

--- a/src/ffi_handle.cpp
+++ b/src/ffi_handle.cpp
@@ -40,7 +40,7 @@ void FfiHandle::reset(uintptr_t new_handle) noexcept {
 }
 
 uintptr_t FfiHandle::release() noexcept {
-  uintptr_t old = handle_;
+  const uintptr_t old = handle_;
   handle_ = 0;
   return old;
 }

--- a/src/local_audio_track.cpp
+++ b/src/local_audio_track.cpp
@@ -38,7 +38,7 @@ std::shared_ptr<LocalAudioTrack> LocalAudioTrack::createLocalAudioTrack(
   msg->set_name(name);
   msg->set_source_handle(static_cast<uint64_t>(source->ffi_handle_id()));
 
-  proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
+  const proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
   const proto::OwnedTrack &owned = resp.create_audio_track().track();
   FfiHandle handle(static_cast<uintptr_t>(owned.handle().id()));
   return std::shared_ptr<LocalAudioTrack>(

--- a/src/local_data_track.cpp
+++ b/src/local_data_track.cpp
@@ -52,7 +52,7 @@ LocalDataTrack::tryPush(const DataTrackFrame &frame) {
       pf->set_user_timestamp(frame.user_timestamp.value());
     }
 
-    proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
+    const proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
     const auto &r = resp.local_data_track_try_push();
     if (r.has_error()) {
       return Result<void, LocalDataTrackTryPushError>::failure(
@@ -84,7 +84,7 @@ bool LocalDataTrack::isPublished() const {
   auto *msg = req.mutable_local_data_track_is_published();
   msg->set_track_handle(static_cast<uint64_t>(handle_.get()));
 
-  proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
+  const proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
   return resp.local_data_track_is_published().is_published();
 }
 

--- a/src/local_video_track.cpp
+++ b/src/local_video_track.cpp
@@ -38,7 +38,7 @@ std::shared_ptr<LocalVideoTrack> LocalVideoTrack::createLocalVideoTrack(
   msg->set_name(name);
   msg->set_source_handle(static_cast<uint64_t>(source->ffi_handle_id()));
 
-  proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
+  const proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
   const proto::OwnedTrack &owned = resp.create_video_track().track();
   FfiHandle handle(static_cast<uintptr_t>(owned.handle().id()));
   return std::shared_ptr<LocalVideoTrack>(

--- a/src/remote_data_track.cpp
+++ b/src/remote_data_track.cpp
@@ -63,7 +63,7 @@ RemoteDataTrack::subscribe(const DataTrackStream::Options &options) {
                   SubscribeDataTrackError>::failure(std::move(result).error());
   }
 
-  proto::OwnedDataTrackStream owned_sub = result.value();
+  const proto::OwnedDataTrackStream owned_sub = result.value();
 
   FfiHandle sub_handle(static_cast<uintptr_t>(owned_sub.handle().id()));
 

--- a/src/remote_data_track.cpp
+++ b/src/remote_data_track.cpp
@@ -42,7 +42,7 @@ bool RemoteDataTrack::isPublished() const {
   auto *msg = req.mutable_remote_data_track_is_published();
   msg->set_track_handle(static_cast<uint64_t>(handle_.get()));
 
-  proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
+  const proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
   return resp.remote_data_track_is_published().is_published();
 }
 

--- a/src/room.cpp
+++ b/src/room.cpp
@@ -1065,11 +1065,11 @@ void Room::OnEvent(const FfiEvent &event) {
       }
       const auto which_val = dp.value_case();
       if (which_val == proto::DataPacketReceived::kUser && delegate_snapshot) {
-        UserDataPacketEvent ev = userDataPacketFromProto(dp, rp);
+        const UserDataPacketEvent ev = userDataPacketFromProto(dp, rp);
         delegate_snapshot->onUserPacketReceived(*this, ev);
       } else if (which_val == proto::DataPacketReceived::kSipDtmf &&
                  delegate_snapshot) {
-        SipDtmfReceivedEvent ev = sipDtmfFromProto(dp, rp);
+        const SipDtmfReceivedEvent ev = sipDtmfFromProto(dp, rp);
         delegate_snapshot->onSipDtmfReceived(*this, ev);
       }
       break;
@@ -1140,14 +1140,14 @@ void Room::OnEvent(const FfiEvent &event) {
       break;
     }
     case proto::RoomEvent::kReconnecting: {
-      ReconnectingEvent ev;
+      const ReconnectingEvent ev;
       if (delegate_snapshot) {
         delegate_snapshot->onReconnecting(*this, ev);
       }
       break;
     }
     case proto::RoomEvent::kReconnected: {
-      ReconnectedEvent ev;
+      const ReconnectedEvent ev;
       if (delegate_snapshot) {
         delegate_snapshot->onReconnected(*this, ev);
       }
@@ -1196,7 +1196,7 @@ void Room::OnEvent(const FfiEvent &event) {
 
       // Old state will be destroyed here when going out of scope
 
-      RoomEosEvent ev;
+      const RoomEosEvent ev;
       if (delegate_snapshot) {
         delegate_snapshot->onRoomEos(*this, ev);
       }
@@ -1231,7 +1231,7 @@ void Room::OnEvent(const FfiEvent &event) {
           }
           text_cb = it->second;
 
-          TextStreamInfo info = makeTextInfo(header);
+          const TextStreamInfo info = makeTextInfo(header);
           text_reader = std::make_shared<TextStreamReader>(info);
           text_stream_readers_[header.stream_id()] = text_reader;
 
@@ -1241,7 +1241,7 @@ void Room::OnEvent(const FfiEvent &event) {
             break;
           }
           byte_cb = it->second;
-          ByteStreamInfo info = makeByteInfo(header);
+          const ByteStreamInfo info = makeByteInfo(header);
           byte_reader = std::make_shared<ByteStreamReader>(info);
           byte_stream_readers_[header.stream_id()] = byte_reader;
 

--- a/src/subscription_thread_dispatcher.cpp
+++ b/src/subscription_thread_dispatcher.cpp
@@ -54,8 +54,8 @@ SubscriptionThreadDispatcher::~SubscriptionThreadDispatcher() {
 void SubscriptionThreadDispatcher::setOnAudioFrameCallback(
     const std::string &participant_identity, TrackSource source,
     AudioFrameCallback callback, AudioStream::Options opts) {
-  CallbackKey key{participant_identity, source, ""};
-  std::lock_guard<std::mutex> lock(lock_);
+  const CallbackKey key{participant_identity, source, ""};
+  const std::lock_guard<std::mutex> lock(lock_);
   const bool replacing = audio_callbacks_.find(key) != audio_callbacks_.end();
   audio_callbacks_[key] =
       RegisteredAudioCallback{std::move(callback), std::move(opts)};
@@ -68,9 +68,9 @@ void SubscriptionThreadDispatcher::setOnAudioFrameCallback(
 void SubscriptionThreadDispatcher::setOnAudioFrameCallback(
     const std::string &participant_identity, const std::string &track_name,
     AudioFrameCallback callback, AudioStream::Options opts) {
-  CallbackKey key{participant_identity, TrackSource::SOURCE_UNKNOWN,
-                  track_name};
-  std::lock_guard<std::mutex> lock(lock_);
+  const CallbackKey key{participant_identity, TrackSource::SOURCE_UNKNOWN,
+                        track_name};
+  const std::lock_guard<std::mutex> lock(lock_);
   const bool replacing = audio_callbacks_.find(key) != audio_callbacks_.end();
   audio_callbacks_[key] =
       RegisteredAudioCallback{std::move(callback), std::move(opts)};
@@ -83,8 +83,8 @@ void SubscriptionThreadDispatcher::setOnAudioFrameCallback(
 void SubscriptionThreadDispatcher::setOnVideoFrameCallback(
     const std::string &participant_identity, TrackSource source,
     VideoFrameCallback callback, VideoStream::Options opts) {
-  CallbackKey key{participant_identity, source, ""};
-  std::lock_guard<std::mutex> lock(lock_);
+  const CallbackKey key{participant_identity, source, ""};
+  const std::lock_guard<std::mutex> lock(lock_);
   const bool replacing = video_callbacks_.find(key) != video_callbacks_.end();
   video_callbacks_[key] =
       RegisteredVideoCallback{std::move(callback), opts};
@@ -97,9 +97,9 @@ void SubscriptionThreadDispatcher::setOnVideoFrameCallback(
 void SubscriptionThreadDispatcher::setOnVideoFrameCallback(
     const std::string &participant_identity, const std::string &track_name,
     VideoFrameCallback callback, VideoStream::Options opts) {
-  CallbackKey key{participant_identity, TrackSource::SOURCE_UNKNOWN,
-                  track_name};
-  std::lock_guard<std::mutex> lock(lock_);
+  const CallbackKey key{participant_identity, TrackSource::SOURCE_UNKNOWN,
+                        track_name};
+  const std::lock_guard<std::mutex> lock(lock_);
   const bool replacing = video_callbacks_.find(key) != video_callbacks_.end();
   video_callbacks_[key] =
       RegisteredVideoCallback{std::move(callback), opts};
@@ -111,11 +111,11 @@ void SubscriptionThreadDispatcher::setOnVideoFrameCallback(
 
 void SubscriptionThreadDispatcher::clearOnAudioFrameCallback(
     const std::string &participant_identity, TrackSource source) {
-  CallbackKey key{participant_identity, source, ""};
+  const CallbackKey key{participant_identity, source, ""};
   std::thread old_thread;
   bool removed_callback = false;
   {
-    std::lock_guard<std::mutex> lock(lock_);
+    const std::lock_guard<std::mutex> lock(lock_);
     removed_callback = audio_callbacks_.erase(key) > 0;
     old_thread = extractReaderThreadLocked(key);
     LK_LOG_DEBUG(
@@ -131,12 +131,12 @@ void SubscriptionThreadDispatcher::clearOnAudioFrameCallback(
 
 void SubscriptionThreadDispatcher::clearOnAudioFrameCallback(
     const std::string &participant_identity, const std::string &track_name) {
-  CallbackKey key{participant_identity, TrackSource::SOURCE_UNKNOWN,
-                  track_name};
+  const CallbackKey key{participant_identity, TrackSource::SOURCE_UNKNOWN,
+                        track_name};
   std::thread old_thread;
   bool removed_callback = false;
   {
-    std::lock_guard<std::mutex> lock(lock_);
+    const std::lock_guard<std::mutex> lock(lock_);
     removed_callback = audio_callbacks_.erase(key) > 0;
     old_thread = extractReaderThreadLocked(key);
     LK_LOG_DEBUG(
@@ -152,11 +152,11 @@ void SubscriptionThreadDispatcher::clearOnAudioFrameCallback(
 
 void SubscriptionThreadDispatcher::clearOnVideoFrameCallback(
     const std::string &participant_identity, TrackSource source) {
-  CallbackKey key{participant_identity, source, ""};
+  const CallbackKey key{participant_identity, source, ""};
   std::thread old_thread;
   bool removed_callback = false;
   {
-    std::lock_guard<std::mutex> lock(lock_);
+    const std::lock_guard<std::mutex> lock(lock_);
     removed_callback = video_callbacks_.erase(key) > 0;
     old_thread = extractReaderThreadLocked(key);
     LK_LOG_DEBUG(
@@ -172,12 +172,12 @@ void SubscriptionThreadDispatcher::clearOnVideoFrameCallback(
 
 void SubscriptionThreadDispatcher::clearOnVideoFrameCallback(
     const std::string &participant_identity, const std::string &track_name) {
-  CallbackKey key{participant_identity, TrackSource::SOURCE_UNKNOWN,
-                  track_name};
+  const CallbackKey key{participant_identity, TrackSource::SOURCE_UNKNOWN,
+                        track_name};
   std::thread old_thread;
   bool removed_callback = false;
   {
-    std::lock_guard<std::mutex> lock(lock_);
+    const std::lock_guard<std::mutex> lock(lock_);
     removed_callback = video_callbacks_.erase(key) > 0;
     old_thread = extractReaderThreadLocked(key);
     LK_LOG_DEBUG(
@@ -208,10 +208,10 @@ void SubscriptionThreadDispatcher::handleTrackSubscribed(
 
   CallbackKey key{participant_identity, TrackSource::SOURCE_UNKNOWN,
                   track_name};
-  CallbackKey fallback_key{participant_identity, source, ""};
+  const CallbackKey fallback_key{participant_identity, source, ""};
   std::thread old_thread;
   {
-    std::lock_guard<std::mutex> lock(lock_);
+    const std::lock_guard<std::mutex> lock(lock_);
     if ((track->kind() == TrackKind::KIND_AUDIO &&
          audio_callbacks_.find(key) == audio_callbacks_.end()) ||
         (track->kind() == TrackKind::KIND_VIDEO &&
@@ -228,13 +228,13 @@ void SubscriptionThreadDispatcher::handleTrackSubscribed(
 void SubscriptionThreadDispatcher::handleTrackUnsubscribed(
     const std::string &participant_identity, TrackSource source,
     const std::string &track_name) {
-  CallbackKey key{participant_identity, TrackSource::SOURCE_UNKNOWN,
-                  track_name};
-  CallbackKey fallback_key{participant_identity, source, ""};
+  const CallbackKey key{participant_identity, TrackSource::SOURCE_UNKNOWN,
+                        track_name};
+  const CallbackKey fallback_key{participant_identity, source, ""};
   std::thread old_thread;
   std::thread fallback_old_thread;
   {
-    std::lock_guard<std::mutex> lock(lock_);
+    const std::lock_guard<std::mutex> lock(lock_);
     old_thread = extractReaderThreadLocked(key);
     fallback_old_thread = extractReaderThreadLocked(fallback_key);
     LK_LOG_DEBUG("Handling unsubscribed track for participant={} source={} "
@@ -260,9 +260,9 @@ DataFrameCallbackId SubscriptionThreadDispatcher::addOnDataFrameCallback(
   std::thread old_thread;
   DataFrameCallbackId id;
   {
-    std::lock_guard<std::mutex> lock(lock_);
+    const std::lock_guard<std::mutex> lock(lock_);
     id = next_data_callback_id_++;
-    DataCallbackKey key{participant_identity, track_name};
+    const DataCallbackKey key{participant_identity, track_name};
     data_callbacks_[id] = RegisteredDataCallback{key, std::move(callback)};
 
     auto track_it = remote_data_tracks_.find(key);
@@ -281,7 +281,7 @@ void SubscriptionThreadDispatcher::removeOnDataFrameCallback(
     DataFrameCallbackId id) {
   std::thread old_thread;
   {
-    std::lock_guard<std::mutex> lock(lock_);
+    const std::lock_guard<std::mutex> lock(lock_);
     data_callbacks_.erase(id);
     old_thread = extractDataReaderThreadLocked(id);
   }
@@ -303,8 +303,8 @@ void SubscriptionThreadDispatcher::handleDataTrackPublished(
 
   std::vector<std::thread> old_threads;
   {
-    std::lock_guard<std::mutex> lock(lock_);
-    DataCallbackKey key{track->publisherIdentity(), track->info().name};
+    const std::lock_guard<std::mutex> lock(lock_);
+    const DataCallbackKey key{track->publisherIdentity(), track->info().name};
     remote_data_tracks_[key] = track;
 
     for (auto &[id, reg] : data_callbacks_) {
@@ -327,13 +327,13 @@ void SubscriptionThreadDispatcher::handleDataTrackUnpublished(
 
   std::vector<std::thread> old_threads;
   {
-    std::lock_guard<std::mutex> lock(lock_);
+    const std::lock_guard<std::mutex> lock(lock_);
     for (auto it = active_data_readers_.begin();
          it != active_data_readers_.end();) {
       auto &reader = it->second;
       if (reader->remote_track && reader->remote_track->info().sid == sid) {
         {
-          std::lock_guard<std::mutex> sub_guard(reader->sub_mutex);
+          const std::lock_guard<std::mutex> sub_guard(reader->sub_mutex);
           if (reader->stream) {
             reader->stream->close();
           }
@@ -362,7 +362,7 @@ void SubscriptionThreadDispatcher::handleDataTrackUnpublished(
 void SubscriptionThreadDispatcher::stopAll() {
   std::vector<std::thread> threads;
   {
-    std::lock_guard<std::mutex> lock(lock_);
+    const std::lock_guard<std::mutex> lock(lock_);
     LK_LOG_DEBUG("Stopping all subscription readers active_readers={} "
                  "active_data_readers={} audio_callbacks={} "
                  "video_callbacks={} data_callbacks={}",
@@ -387,7 +387,7 @@ void SubscriptionThreadDispatcher::stopAll() {
 
     for (auto &[id, reader] : active_data_readers_) {
       {
-        std::lock_guard<std::mutex> sub_guard(reader->sub_mutex);
+        const std::lock_guard<std::mutex> sub_guard(reader->sub_mutex);
         if (reader->stream) {
           reader->stream->close();
         }
@@ -589,7 +589,7 @@ std::thread SubscriptionThreadDispatcher::extractDataReaderThreadLocked(
   auto reader = std::move(it->second);
   active_data_readers_.erase(it);
   {
-    std::lock_guard<std::mutex> guard(reader->sub_mutex);
+    const std::lock_guard<std::mutex> guard(reader->sub_mutex);
     if (reader->stream) {
       reader->stream->close();
     }
@@ -608,7 +608,7 @@ std::thread SubscriptionThreadDispatcher::extractDataReaderThreadLocked(
       auto reader = std::move(it->second);
       active_data_readers_.erase(it);
       {
-        std::lock_guard<std::mutex> guard(reader->sub_mutex);
+        const std::lock_guard<std::mutex> guard(reader->sub_mutex);
         if (reader->stream) {
           reader->stream->close();
         }
@@ -660,7 +660,7 @@ std::thread SubscriptionThreadDispatcher::startDataReaderLocked(
                 identity, track_name);
 
     {
-      std::lock_guard<std::mutex> guard(reader->sub_mutex);
+      const std::lock_guard<std::mutex> guard(reader->sub_mutex);
       reader->stream = stream;
     }
 

--- a/src/track_proto_converter.cpp
+++ b/src/track_proto_converter.cpp
@@ -118,7 +118,7 @@ std::vector<AudioTrackFeature>
 convertAudioFeatures(const google::protobuf::RepeatedField<int> &features) {
   std::vector<AudioTrackFeature> out;
   out.reserve(features.size());
-  for (int v : features) {
+  for (const int v : features) {
     out.push_back(fromProto(static_cast<proto::AudioTrackFeature>(v)));
   }
   return out;

--- a/src/video_frame.cpp
+++ b/src/video_frame.cpp
@@ -130,19 +130,19 @@ computePlaneInfos(uintptr_t base, int width, int height, VideoBufferType type) {
     // Y
     const uint32_t y_stride = w;
     const uint32_t y_size = w * h;
-    uintptr_t y_ptr = base;
+    const uintptr_t y_ptr = base;
     pushPlane(y_ptr, y_stride, y_size);
 
     // U
     const uint32_t u_stride = chroma_w;
     const uint32_t u_size = chroma_w * chroma_h;
-    uintptr_t u_ptr = y_ptr + y_size;
+    const uintptr_t u_ptr = y_ptr + y_size;
     pushPlane(u_ptr, u_stride, u_size);
 
     // V
     const uint32_t v_stride = chroma_w;
     const uint32_t v_size = chroma_w * chroma_h;
-    uintptr_t v_ptr = u_ptr + u_size;
+    const uintptr_t v_ptr = u_ptr + u_size;
     pushPlane(v_ptr, v_stride, v_size);
     break;
   }
@@ -154,25 +154,25 @@ computePlaneInfos(uintptr_t base, int width, int height, VideoBufferType type) {
     // Y
     const uint32_t y_stride = w;
     const uint32_t y_size = w * h;
-    uintptr_t y_ptr = base;
+    const uintptr_t y_ptr = base;
     pushPlane(y_ptr, y_stride, y_size);
 
     // U
     const uint32_t u_stride = chroma_w;
     const uint32_t u_size = chroma_w * chroma_h;
-    uintptr_t u_ptr = y_ptr + y_size;
+    const uintptr_t u_ptr = y_ptr + y_size;
     pushPlane(u_ptr, u_stride, u_size);
 
     // V
     const uint32_t v_stride = chroma_w;
     const uint32_t v_size = chroma_w * chroma_h;
-    uintptr_t v_ptr = u_ptr + u_size;
+    const uintptr_t v_ptr = u_ptr + u_size;
     pushPlane(v_ptr, v_stride, v_size);
 
     // A (full res)
     const uint32_t a_stride = w;
     const uint32_t a_size = w * h;
-    uintptr_t a_ptr = v_ptr + v_size;
+    const uintptr_t a_ptr = v_ptr + v_size;
     pushPlane(a_ptr, a_stride, a_size);
     break;
   }
@@ -183,19 +183,19 @@ computePlaneInfos(uintptr_t base, int width, int height, VideoBufferType type) {
     // Y
     const uint32_t y_stride = w;
     const uint32_t y_size = w * h;
-    uintptr_t y_ptr = base;
+    const uintptr_t y_ptr = base;
     pushPlane(y_ptr, y_stride, y_size);
 
     // U
     const uint32_t u_stride = chroma_w;
     const uint32_t u_size = chroma_w * h;
-    uintptr_t u_ptr = y_ptr + y_size;
+    const uintptr_t u_ptr = y_ptr + y_size;
     pushPlane(u_ptr, u_stride, u_size);
 
     // V
     const uint32_t v_stride = chroma_w;
     const uint32_t v_size = chroma_w * h;
-    uintptr_t v_ptr = u_ptr + u_size;
+    const uintptr_t v_ptr = u_ptr + u_size;
     pushPlane(v_ptr, v_stride, v_size);
     break;
   }
@@ -204,17 +204,17 @@ computePlaneInfos(uintptr_t base, int width, int height, VideoBufferType type) {
     // All planes full-res
     const uint32_t y_stride = w;
     const uint32_t y_size = w * h;
-    uintptr_t y_ptr = base;
+    const uintptr_t y_ptr = base;
     pushPlane(y_ptr, y_stride, y_size);
 
     const uint32_t u_stride = w;
     const uint32_t u_size = w * h;
-    uintptr_t u_ptr = y_ptr + y_size;
+    const uintptr_t u_ptr = y_ptr + y_size;
     pushPlane(u_ptr, u_stride, u_size);
 
     const uint32_t v_stride = w;
     const uint32_t v_size = w * h;
-    uintptr_t v_ptr = u_ptr + u_size;
+    const uintptr_t v_ptr = u_ptr + u_size;
     pushPlane(v_ptr, v_stride, v_size);
     break;
   }
@@ -227,19 +227,19 @@ computePlaneInfos(uintptr_t base, int width, int height, VideoBufferType type) {
     // Y
     const uint32_t y_stride = w * 2;
     const uint32_t y_size = w * h * 2;
-    uintptr_t y_ptr = base;
+    const uintptr_t y_ptr = base;
     pushPlane(y_ptr, y_stride, y_size);
 
     // U
     const uint32_t u_stride = chroma_w * 2;
     const uint32_t u_size = chroma_w * chroma_h * 2;
-    uintptr_t u_ptr = y_ptr + y_size;
+    const uintptr_t u_ptr = y_ptr + y_size;
     pushPlane(u_ptr, u_stride, u_size);
 
     // V
     const uint32_t v_stride = chroma_w * 2;
     const uint32_t v_size = chroma_w * chroma_h * 2;
-    uintptr_t v_ptr = u_ptr + u_size;
+    const uintptr_t v_ptr = u_ptr + u_size;
     pushPlane(v_ptr, v_stride, v_size);
     break;
   }
@@ -251,13 +251,13 @@ computePlaneInfos(uintptr_t base, int width, int height, VideoBufferType type) {
     // Y
     const uint32_t y_stride = w;
     const uint32_t y_size = w * h;
-    uintptr_t y_ptr = base;
+    const uintptr_t y_ptr = base;
     pushPlane(y_ptr, y_stride, y_size);
 
     // UV interleaved
     const uint32_t uv_stride = chroma_w * 2;
     const uint32_t uv_size = chroma_w * chroma_h * 2;
-    uintptr_t uv_ptr = y_ptr + y_size;
+    const uintptr_t uv_ptr = y_ptr + y_size;
     pushPlane(uv_ptr, uv_stride, uv_size);
     break;
   }

--- a/src/video_frame.cpp
+++ b/src/video_frame.cpp
@@ -98,10 +98,7 @@ computePlaneInfos(uintptr_t base, int width, int height, VideoBufferType type) {
   const auto w = static_cast<uint32_t>(width);
   const auto h = static_cast<uint32_t>(height);
   auto pushPlane = [&](uintptr_t ptr, uint32_t stride, uint32_t size) {
-    VideoPlaneInfo info;
-    info.data_ptr = ptr;
-    info.stride = stride;
-    info.size = size;
+    const VideoPlaneInfo info{ptr, stride, size};
     planes.push_back(info);
   };
 
@@ -300,7 +297,7 @@ std::vector<VideoPlaneInfo> VideoFrame::planeInfos() const {
     return {};
   }
 
-  uintptr_t base = reinterpret_cast<uintptr_t>(data_.data());
+  const uintptr_t base = reinterpret_cast<uintptr_t>(data_.data());
   return computePlaneInfos(base, width_, height_, type_);
 }
 
@@ -366,7 +363,7 @@ VideoFrame VideoFrame::fromOwnedInfo(const proto::OwnedVideoBuffer &owned) {
 
   // Release the FFI-owned buffer after copying the data.
   {
-    FfiHandle owned_handle(static_cast<std::uintptr_t>(owned.handle().id()));
+    const FfiHandle owned_handle(static_cast<std::uintptr_t>(owned.handle().id()));
     // owned_handle destroyed at end of scope → native buffer disposed.
   }
 

--- a/src/video_source.cpp
+++ b/src/video_source.cpp
@@ -51,14 +51,14 @@ void VideoSource::captureFrame(const VideoFrame &frame,
     return;
   }
 
-  proto::VideoBufferInfo buf = toProto(frame);
+  const proto::VideoBufferInfo buf = toProto(frame);
   proto::FfiRequest req;
   auto *msg = req.mutable_capture_video_frame();
   msg->set_source_handle(handle_.get());
   msg->mutable_buffer()->CopyFrom(buf);
   msg->set_timestamp_us(timestamp_us);
   msg->set_rotation(static_cast<proto::VideoRotation>(rotation));
-  proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
+  const proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
   if (!resp.has_capture_video_frame()) {
     throw std::runtime_error("FfiResponse missing capture_video_frame");
   }

--- a/src/video_utils.cpp
+++ b/src/video_utils.cpp
@@ -152,7 +152,7 @@ VideoFrame fromOwnedProto(const proto::OwnedVideoBuffer &owned) {
 
   // Drop the owned FFI handle to let the core free its side.
   {
-    FfiHandle tmp(owned.handle().id());
+    const FfiHandle tmp(owned.handle().id());
     // tmp destructor will dispose the handle via FFI.
   }
 
@@ -167,7 +167,7 @@ VideoFrame convertViaFfi(const VideoFrame &frame, VideoBufferType dst,
   vc->set_dst_type(toProto(dst));
   vc->mutable_buffer()->CopyFrom(toProto(frame));
 
-  proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
+  const proto::FfiResponse resp = FfiClient::instance().sendRequest(req);
   if (!resp.has_video_convert()) {
     throw std::runtime_error(
         "convertViaFfi: FfiResponse missing video_convert");


### PR DESCRIPTION
Follow on PR from #97 to enable `misc-const-correctness` check and apply fixes where it makes sense to.

Note that on an entire repo run for this check, there were some areas of the code that required minor refactors to achieve `const` on the flagged lines. I opted not to touch these areas (not worth risk of changing), and they're not flagged because the `cpp-linter` is only set to check changed lines.