### PR TITLE
Other minor fixes to remove unused headers and correct some comments

### DIFF
--- a/include/livekit/local_track_publication.h
+++ b/include/livekit/local_track_publication.h
@@ -28,7 +28,7 @@ class Track;
 
 class LocalTrackPublication : public TrackPublication {
 public:
-  /// Note, this RemoteTrackPublication is constructed internally only;
+  /// Note, this LocalTrackPublication is constructed internally only;
   /// safe to accept proto::OwnedTrackPublication.
   explicit LocalTrackPublication(const proto::OwnedTrackPublication &owned);
 

--- a/include/livekit/remote_video_track.h
+++ b/include/livekit/remote_video_track.h
@@ -50,8 +50,6 @@ public:
   /// Returns a concise, human-readable string summarizing the track,
   /// including its SID and name. Useful for debugging and logging.
   std::string to_string() const;
-
-private:
 };
 
 } // namespace livekit

--- a/include/livekit/track.h
+++ b/include/livekit/track.h
@@ -25,8 +25,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <iostream>
-
 namespace livekit {
 
 class LocalTrackPublication;

--- a/include/livekit/video_stream.h
+++ b/include/livekit/video_stream.h
@@ -47,8 +47,8 @@ class FfiEvent;
 //
 // Typical usage:
 //
-//   AudioStream::Options opts;
-//   auto stream = AudioStream::fromTrack(remoteAudioTrack, opts);
+//   VideoStream::Options opts;
+//   auto stream = VideoStream::fromTrack(remoteVideoTrack, opts);
 //
 //   AudioFrameEvent ev;
 //   while (stream->read(ev)) {

--- a/src/remote_audio_track.cpp
+++ b/src/remote_audio_track.cpp
@@ -18,7 +18,6 @@
 
 #include "ffi.pb.h"
 #include "ffi_client.h"
-#include "livekit/audio_source.h"
 #include "track.pb.h"
 #include "track_proto_converter.h"
 

--- a/src/remote_video_track.cpp
+++ b/src/remote_video_track.cpp
@@ -18,7 +18,6 @@
 
 #include "ffi.pb.h"
 #include "ffi_client.h"
-#include "livekit/video_source.h"
 #include "track.pb.h"
 #include "track_proto_converter.h"
 


### PR DESCRIPTION
### Summary
This PR applies a small set of non-invasive fixes in the C++ SDK.
All changes are documentation/comment corrections or include hygiene improvements, with no intended runtime behavior changes.

### Changes
- Changed RemoteTrackPublication to LocalTrackPublication in the constructor note.
- Removed empty private section in remote_video_track.h
- Removed unused iostream include from track.h
This avoids unnecessarily pulling a heavy standard header through a widely included public header.
- Fixed VideoStream usage example in video_stream.h
Updated sample snippet to use VideoStream types and symbols instead of AudioStream names.
- Removed unused include in remote_audio_track.cpp
- Removed unused include in remote_video_track.cpp

### Notes
No functional logic was changed.
No API signatures were changed.
Changes are limited to comments, examples, access-section cleanup, and unused includes.
