### PR TITLE
Remove registration of video/audio callbacks based on TrackSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,10 @@ lk token create \
   --grant '{"canPublish":true,"canSubscribe":true,"canPublishData":true}'
 ```
 
+# Deprecation
+- livekit_bridge (bridge/ folder) is deprecated. Avoid using it. Migrate to the base SDK. This will be removed on 06/01/2026.
+- setOn*FrameCallback with TrackSource is deprecated. Use track name instead. This will be removed on 06/01/2026.
+
 <!--BEGIN_REPO_NAV-->
 <br/><table>
 <thead><tr><th colspan="2">LiveKit Ecosystem</th></tr></thead>


### PR DESCRIPTION
bridge changes were only applied to truly purge the public API of this improper implementation.