### PR TITLE
Adjust result.h error condition behavior

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -53,7 +53,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   # Pinned commit for cpp-example-collection smoke build (https://github.com/livekit-examples/cpp-example-collection)
-  CPP_EXAMPLE_COLLECTION_REF: f231c0c75028d1dcf13edcecd369d030d2c7c8d4
+  CPP_EXAMPLE_COLLECTION_REF: 46083ea4e5d3def8e44a53148c2c7800131efca0
   # vcpkg binary caching for Windows
   VCPKG_DEFAULT_TRIPLET: x64-windows-static-md
   VCPKG_DEFAULT_HOST_TRIPLET: x64-windows-static-md

--- a/include/livekit/result.h
+++ b/include/livekit/result.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <cassert>
 #include <optional>
+#include <stdexcept>
 #include <type_traits>
 #include <utility>
 #include <variant>
@@ -34,9 +34,10 @@ namespace livekit {
  * - a success value of type `T`, or
  * - an error value of type `E`
  *
- * Accessors are intentionally non-throwing. Calling `value()` on an error
- * result, or `error()` on a success result, is a programmer error and will
- * trip the debug assertion.
+ * Accessors validate their preconditions before returning. Calling `value()`
+ * on an error result, or `error()` on a success result, throws
+ * `std::runtime_error`. Always check `ok()` / `has_error()` (or the `bool`
+ * conversion) before calling `value()` or `error()`.
  */
 template <typename T, typename E>
 class [[nodiscard]] Result {
@@ -60,64 +61,83 @@ public:
   /// Allows `if (result)` style success checks.
   explicit operator bool() const noexcept { return ok(); }
 
-  // TODO (AEG): clang-tidy flagged these accessors because the signatures are
-  // marked noexcept, but std::get can throw a std::bad_variant_access exception
-  // on std::variant specifically. Investigate if this is actually a concern or
-  // if the types are safe within this class (unit test ideal).
-
-  /// Access the success value. Requires `ok() == true`.
-  // NOLINTNEXTLINE(bugprone-exception-escape)
-  T& value() & noexcept {
-    assert(ok());
+  /// Access the success value.
+  ///
+  /// @throws std::runtime_error if `ok() == false`.
+  T& value() & {
+    if (!ok()) {
+      throw std::runtime_error("Result::value() called on an error result");
+    }
     return std::get<0>(storage_);
   }
 
-  /// Access the success value. Requires `ok() == true`.
-  // NOLINTNEXTLINE(bugprone-exception-escape)
-  const T& value() const& noexcept {
-    assert(ok());
+  /// Access the success value.
+  ///
+  /// @throws std::runtime_error if `ok() == false`.
+  const T& value() const& {
+    if (!ok()) {
+      throw std::runtime_error("Result::value() called on an error result");
+    }
     return std::get<0>(storage_);
   }
 
-  /// Move the success value out. Requires `ok() == true`.
-  // NOLINTNEXTLINE(bugprone-exception-escape)
-  T&& value() && noexcept {
-    assert(ok());
+  /// Move the success value out.
+  ///
+  /// @throws std::runtime_error if `ok() == false`.
+  T&& value() && {
+    if (!ok()) {
+      throw std::runtime_error("Result::value() called on an error result");
+    }
     return std::get<0>(std::move(storage_));
   }
 
-  /// Move the success value out. Requires `ok() == true`.
-  // NOLINTNEXTLINE(bugprone-exception-escape)
-  const T&& value() const&& noexcept {
-    assert(ok());
+  /// Move the success value out.
+  ///
+  /// @throws std::runtime_error if `ok() == false`.
+  const T&& value() const&& {
+    if (!ok()) {
+      throw std::runtime_error("Result::value() called on an error result");
+    }
     return std::get<0>(std::move(storage_));
   }
 
-  /// Access the error value. Requires `has_error() == true`.
-  // NOLINTNEXTLINE(bugprone-exception-escape)
-  E& error() & noexcept {
-    assert(has_error());
+  /// Access the error value.
+  ///
+  /// @throws std::runtime_error if `has_error() == false`.
+  E& error() & {
+    if (!has_error()) {
+      throw std::runtime_error("Result::error() called on a success result");
+    }
     return std::get<1>(storage_);
   }
 
-  /// Access the error value. Requires `has_error() == true`.
-  // NOLINTNEXTLINE(bugprone-exception-escape)
-  const E& error() const& noexcept {
-    assert(has_error());
+  /// Access the error value.
+  ///
+  /// @throws std::runtime_error if `has_error() == false`.
+  const E& error() const& {
+    if (!has_error()) {
+      throw std::runtime_error("Result::error() called on a success result");
+    }
     return std::get<1>(storage_);
   }
 
-  /// Move the error value out. Requires `has_error() == true`.
-  // NOLINTNEXTLINE(bugprone-exception-escape)
-  E&& error() && noexcept {
-    assert(has_error());
+  /// Move the error value out.
+  ///
+  /// @throws std::runtime_error if `has_error() == false`.
+  E&& error() && {
+    if (!has_error()) {
+      throw std::runtime_error("Result::error() called on a success result");
+    }
     return std::get<1>(std::move(storage_));
   }
 
-  /// Move the error value out. Requires `has_error() == true`.
-  // NOLINTNEXTLINE(bugprone-exception-escape)
-  const E&& error() const&& noexcept {
-    assert(has_error());
+  /// Move the error value out.
+  ///
+  /// @throws std::runtime_error if `has_error() == false`.
+  const E&& error() const&& {
+    if (!has_error()) {
+      throw std::runtime_error("Result::error() called on a success result");
+    }
     return std::get<1>(std::move(storage_));
   }
 
@@ -152,30 +172,53 @@ public:
   /// Allows `if (result)` style success checks.
   explicit operator bool() const noexcept { return ok(); }
 
-  /// Validates success in debug builds. Mirrors the `value()` API shape.
-  void value() const noexcept { assert(ok()); }
+  /// Validates success. Mirrors the `value()` API shape on the primary
+  /// template so generic code can use the same form for both.
+  ///
+  /// @throws std::runtime_error if `ok() == false`.
+  void value() const {
+    if (!ok()) {
+      throw std::runtime_error("Result::value() called on an error result");
+    }
+  }
 
-  /// Access the error value. Requires `has_error() == true`.
-  E& error() & noexcept {
-    assert(has_error());
+  /// Access the error value.
+  ///
+  /// @throws std::runtime_error if `has_error() == false`.
+  E& error() & {
+    if (!error_.has_value()) {
+      throw std::runtime_error("Result::error() called on a success result");
+    }
     return *error_;
   }
 
-  /// Access the error value. Requires `has_error() == true`.
-  const E& error() const& noexcept {
-    assert(has_error());
+  /// Access the error value.
+  ///
+  /// @throws std::runtime_error if `has_error() == false`.
+  const E& error() const& {
+    if (!error_.has_value()) {
+      throw std::runtime_error("Result::error() called on a success result");
+    }
     return *error_;
   }
 
-  /// Move the error value out. Requires `has_error() == true`.
-  E&& error() && noexcept {
-    assert(has_error());
+  /// Move the error value out.
+  ///
+  /// @throws std::runtime_error if `has_error() == false`.
+  E&& error() && {
+    if (!error_.has_value()) {
+      throw std::runtime_error("Result::error() called on a success result");
+    }
     return std::move(*error_);
   }
 
-  /// Move the error value out. Requires `has_error() == true`.
-  const E&& error() const&& noexcept {
-    assert(has_error());
+  /// Move the error value out.
+  ///
+  /// @throws std::runtime_error if `has_error() == false`.
+  const E&& error() const&& {
+    if (!error_.has_value()) {
+      throw std::runtime_error("Result::error() called on a success result");
+    }
     return std::move(*error_);
   }
 

--- a/include/livekit/result.h
+++ b/include/livekit/result.h
@@ -16,6 +16,9 @@
 
 #pragma once
 
+// TODO (AEG) This include (cassert) leaked into downstream cpp examples, removing it here breaks builds.
+// Remove it once examples include it themselves
+#include <cassert>
 #include <optional>
 #include <stdexcept>
 #include <type_traits>

--- a/include/livekit/result.h
+++ b/include/livekit/result.h
@@ -35,9 +35,8 @@ namespace livekit {
  * - an error value of type `E`
  *
  * Accessors validate their preconditions before returning. Calling `value()`
- * on an error result, or `error()` on a success result, throws
- * `std::runtime_error`. Always check `ok()` / `has_error()` (or the `bool`
- * conversion) before calling `value()` or `error()`.
+ * on an error result, or `error()` on a success result, throws `std::logic_error`.
+ * Avoid this by checking `ok()` / `has_error()` / if (result) before calling `value()` or `error()`.
  */
 template <typename T, typename E>
 class [[nodiscard]] Result {
@@ -63,80 +62,80 @@ public:
 
   /// Access the success value.
   ///
-  /// @throws std::runtime_error if `ok() == false`.
+  /// @throws std::logic_error if `ok() == false`.
   T& value() & {
     if (!ok()) {
-      throw std::runtime_error("Result::value() called on an error result");
+      throw std::logic_error("Result::value() called on an error result");
     }
     return std::get<0>(storage_);
   }
 
   /// Access the success value.
   ///
-  /// @throws std::runtime_error if `ok() == false`.
+  /// @throws std::logic_error if `ok() == false`.
   const T& value() const& {
     if (!ok()) {
-      throw std::runtime_error("Result::value() called on an error result");
+      throw std::logic_error("Result::value() called on an error result");
     }
     return std::get<0>(storage_);
   }
 
   /// Move the success value out.
   ///
-  /// @throws std::runtime_error if `ok() == false`.
+  /// @throws std::logic_error if `ok() == false`.
   T&& value() && {
     if (!ok()) {
-      throw std::runtime_error("Result::value() called on an error result");
+      throw std::logic_error("Result::value() called on an error result");
     }
     return std::get<0>(std::move(storage_));
   }
 
   /// Move the success value out.
   ///
-  /// @throws std::runtime_error if `ok() == false`.
+  /// @throws std::logic_error if `ok() == false`.
   const T&& value() const&& {
     if (!ok()) {
-      throw std::runtime_error("Result::value() called on an error result");
+      throw std::logic_error("Result::value() called on an error result");
     }
     return std::get<0>(std::move(storage_));
   }
 
   /// Access the error value.
   ///
-  /// @throws std::runtime_error if `has_error() == false`.
+  /// @throws std::logic_error if `has_error() == false`.
   E& error() & {
     if (!has_error()) {
-      throw std::runtime_error("Result::error() called on a success result");
+      throw std::logic_error("Result::error() called on a success result");
     }
     return std::get<1>(storage_);
   }
 
   /// Access the error value.
   ///
-  /// @throws std::runtime_error if `has_error() == false`.
+  /// @throws std::logic_error if `has_error() == false`.
   const E& error() const& {
     if (!has_error()) {
-      throw std::runtime_error("Result::error() called on a success result");
+      throw std::logic_error("Result::error() called on a success result");
     }
     return std::get<1>(storage_);
   }
 
   /// Move the error value out.
   ///
-  /// @throws std::runtime_error if `has_error() == false`.
+  /// @throws std::logic_error if `has_error() == false`.
   E&& error() && {
     if (!has_error()) {
-      throw std::runtime_error("Result::error() called on a success result");
+      throw std::logic_error("Result::error() called on a success result");
     }
     return std::get<1>(std::move(storage_));
   }
 
   /// Move the error value out.
   ///
-  /// @throws std::runtime_error if `has_error() == false`.
+  /// @throws std::logic_error if `has_error() == false`.
   const E&& error() const&& {
     if (!has_error()) {
-      throw std::runtime_error("Result::error() called on a success result");
+      throw std::logic_error("Result::error() called on a success result");
     }
     return std::get<1>(std::move(storage_));
   }
@@ -175,49 +174,49 @@ public:
   /// Validates success. Mirrors the `value()` API shape on the primary
   /// template so generic code can use the same form for both.
   ///
-  /// @throws std::runtime_error if `ok() == false`.
+  /// @throws std::logic_error if `ok() == false`.
   void value() const {
     if (!ok()) {
-      throw std::runtime_error("Result::value() called on an error result");
+      throw std::logic_error("Result::value() called on an error result");
     }
   }
 
   /// Access the error value.
   ///
-  /// @throws std::runtime_error if `has_error() == false`.
+  /// @throws std::logic_error if `has_error() == false`.
   E& error() & {
     if (!error_.has_value()) {
-      throw std::runtime_error("Result::error() called on a success result");
+      throw std::logic_error("Result::error() called on a success result");
     }
     return *error_;
   }
 
   /// Access the error value.
   ///
-  /// @throws std::runtime_error if `has_error() == false`.
+  /// @throws std::logic_error if `has_error() == false`.
   const E& error() const& {
     if (!error_.has_value()) {
-      throw std::runtime_error("Result::error() called on a success result");
+      throw std::logic_error("Result::error() called on a success result");
     }
     return *error_;
   }
 
   /// Move the error value out.
   ///
-  /// @throws std::runtime_error if `has_error() == false`.
+  /// @throws std::logic_error if `has_error() == false`.
   E&& error() && {
     if (!error_.has_value()) {
-      throw std::runtime_error("Result::error() called on a success result");
+      throw std::logic_error("Result::error() called on a success result");
     }
     return std::move(*error_);
   }
 
   /// Move the error value out.
   ///
-  /// @throws std::runtime_error if `has_error() == false`.
+  /// @throws std::logic_error if `has_error() == false`.
   const E&& error() const&& {
     if (!error_.has_value()) {
-      throw std::runtime_error("Result::error() called on a success result");
+      throw std::logic_error("Result::error() called on a success result");
     }
     return std::move(*error_);
   }

--- a/include/livekit/result.h
+++ b/include/livekit/result.h
@@ -16,9 +16,6 @@
 
 #pragma once
 
-// TODO (AEG) This include (cassert) leaked into downstream cpp examples, removing it here breaks builds.
-// Remove it once examples include it themselves
-#include <cassert>
 #include <optional>
 #include <stdexcept>
 #include <type_traits>

--- a/src/tests/unit/test_result.cpp
+++ b/src/tests/unit/test_result.cpp
@@ -28,6 +28,7 @@
 #include <livekit/result.h>
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -132,6 +133,40 @@ TEST(ResultTest, FailureStringError) {
 }
 
 // ---------------------------------------------------------------------------
+// Result<T, E> — precondition violations throw std::runtime_error
+// ---------------------------------------------------------------------------
+
+TEST(ResultTest, ValueOnFailureThrowsRuntimeError) {
+  auto r = Result<int, SimpleError>::failure(SimpleError{1, "oops"});
+  EXPECT_THROW(static_cast<void>(r.value()), std::runtime_error);
+}
+
+TEST(ResultTest, ConstValueOnFailureThrowsRuntimeError) {
+  const auto r = Result<int, SimpleError>::failure(SimpleError{1, "oops"});
+  EXPECT_THROW(static_cast<void>(r.value()), std::runtime_error);
+}
+
+TEST(ResultTest, MoveValueOnFailureThrowsRuntimeError) {
+  auto r = Result<int, SimpleError>::failure(SimpleError{1, "oops"});
+  EXPECT_THROW(static_cast<void>(std::move(r).value()), std::runtime_error);
+}
+
+TEST(ResultTest, ErrorOnSuccessThrowsRuntimeError) {
+  auto r = Result<int, SimpleError>::success(42);
+  EXPECT_THROW(static_cast<void>(r.error()), std::runtime_error);
+}
+
+TEST(ResultTest, ConstErrorOnSuccessThrowsRuntimeError) {
+  const auto r = Result<int, SimpleError>::success(42);
+  EXPECT_THROW(static_cast<void>(r.error()), std::runtime_error);
+}
+
+TEST(ResultTest, MoveErrorOnSuccessThrowsRuntimeError) {
+  auto r = Result<int, SimpleError>::success(42);
+  EXPECT_THROW(static_cast<void>(std::move(r).error()), std::runtime_error);
+}
+
+// ---------------------------------------------------------------------------
 // Result<void, E> — success path
 // ---------------------------------------------------------------------------
 
@@ -184,6 +219,25 @@ TEST(ResultVoidTest, FailureMoveError) {
   auto r = Result<void, std::string>::failure("void error");
   auto msg = std::move(r).error();
   EXPECT_EQ(msg, "void error");
+}
+
+// ---------------------------------------------------------------------------
+// Result<void, E> — precondition violations throw std::runtime_error
+// ---------------------------------------------------------------------------
+
+TEST(ResultVoidTest, ValueOnFailureThrowsRuntimeError) {
+  auto r = Result<void, SimpleError>::failure(SimpleError{1, "oops"});
+  EXPECT_THROW(r.value(), std::runtime_error);
+}
+
+TEST(ResultVoidTest, ErrorOnSuccessThrowsRuntimeError) {
+  auto r = Result<void, SimpleError>::success();
+  EXPECT_THROW(static_cast<void>(r.error()), std::runtime_error);
+}
+
+TEST(ResultVoidTest, MoveErrorOnSuccessThrowsRuntimeError) {
+  auto r = Result<void, SimpleError>::success();
+  EXPECT_THROW(static_cast<void>(std::move(r).error()), std::runtime_error);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests/unit/test_result.cpp
+++ b/src/tests/unit/test_result.cpp
@@ -59,7 +59,7 @@ TEST(ResultTest, SuccessHasErrorIsFalse) {
 
 TEST(ResultTest, SuccessBoolConversionIsTrue) {
   auto r = Result<int, SimpleError>::success(42);
-  EXPECT_TRUE(static_cast<bool>(r));
+  EXPECT_TRUE(r);
 }
 
 TEST(ResultTest, SuccessValueMatchesInput) {
@@ -106,7 +106,7 @@ TEST(ResultTest, FailureHasErrorIsTrue) {
 
 TEST(ResultTest, FailureBoolConversionIsFalse) {
   auto r = Result<int, SimpleError>::failure(SimpleError{1, "oops"});
-  EXPECT_FALSE(static_cast<bool>(r));
+  EXPECT_FALSE(r);
 }
 
 TEST(ResultTest, FailureErrorCodeMatchesInput) {
@@ -138,32 +138,32 @@ TEST(ResultTest, FailureStringError) {
 
 TEST(ResultTest, ValueOnFailureThrowsLogicError) {
   auto r = Result<int, SimpleError>::failure(SimpleError{1, "oops"});
-  EXPECT_THROW(static_cast<void>(r.value()), std::logic_error);
+  EXPECT_THROW(r.value(), std::logic_error);
 }
 
 TEST(ResultTest, ConstValueOnFailureThrowsLogicError) {
   const auto r = Result<int, SimpleError>::failure(SimpleError{1, "oops"});
-  EXPECT_THROW(static_cast<void>(r.value()), std::logic_error);
+  EXPECT_THROW(r.value(), std::logic_error);
 }
 
 TEST(ResultTest, MoveValueOnFailureThrowsLogicError) {
   auto r = Result<int, SimpleError>::failure(SimpleError{1, "oops"});
-  EXPECT_THROW(static_cast<void>(std::move(r).value()), std::logic_error);
+  EXPECT_THROW(std::move(r).value(), std::logic_error);
 }
 
 TEST(ResultTest, ErrorOnSuccessThrowsLogicError) {
   auto r = Result<int, SimpleError>::success(42);
-  EXPECT_THROW(static_cast<void>(r.error()), std::logic_error);
+  EXPECT_THROW(r.error(), std::logic_error);
 }
 
 TEST(ResultTest, ConstErrorOnSuccessThrowsLogicError) {
   const auto r = Result<int, SimpleError>::success(42);
-  EXPECT_THROW(static_cast<void>(r.error()), std::logic_error);
+  EXPECT_THROW(r.error(), std::logic_error);
 }
 
 TEST(ResultTest, MoveErrorOnSuccessThrowsLogicError) {
   auto r = Result<int, SimpleError>::success(42);
-  EXPECT_THROW(static_cast<void>(std::move(r).error()), std::logic_error);
+  EXPECT_THROW(std::move(r).error(), std::logic_error);
 }
 
 // ---------------------------------------------------------------------------
@@ -182,7 +182,7 @@ TEST(ResultVoidTest, SuccessHasErrorIsFalse) {
 
 TEST(ResultVoidTest, SuccessBoolConversionIsTrue) {
   auto r = Result<void, SimpleError>::success();
-  EXPECT_TRUE(static_cast<bool>(r));
+  EXPECT_TRUE(r);
 }
 
 TEST(ResultVoidTest, SuccessValueIsCallable) {
@@ -206,7 +206,7 @@ TEST(ResultVoidTest, FailureHasErrorIsTrue) {
 
 TEST(ResultVoidTest, FailureBoolConversionIsFalse) {
   auto r = Result<void, SimpleError>::failure(SimpleError{5, "void fail"});
-  EXPECT_FALSE(static_cast<bool>(r));
+  EXPECT_FALSE(r);
 }
 
 TEST(ResultVoidTest, FailureErrorMatchesInput) {
@@ -232,12 +232,12 @@ TEST(ResultVoidTest, ValueOnFailureThrowsLogicError) {
 
 TEST(ResultVoidTest, ErrorOnSuccessThrowsLogicError) {
   auto r = Result<void, SimpleError>::success();
-  EXPECT_THROW(static_cast<void>(r.error()), std::logic_error);
+  EXPECT_THROW(r.error(), std::logic_error);
 }
 
 TEST(ResultVoidTest, MoveErrorOnSuccessThrowsLogicError) {
   auto r = Result<void, SimpleError>::success();
-  EXPECT_THROW(static_cast<void>(std::move(r).error()), std::logic_error);
+  EXPECT_THROW(std::move(r).error(), std::logic_error);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tests/unit/test_result.cpp
+++ b/src/tests/unit/test_result.cpp
@@ -133,37 +133,37 @@ TEST(ResultTest, FailureStringError) {
 }
 
 // ---------------------------------------------------------------------------
-// Result<T, E> — precondition violations throw std::runtime_error
+// Result<T, E> — precondition violations throw std::logic_error
 // ---------------------------------------------------------------------------
 
-TEST(ResultTest, ValueOnFailureThrowsRuntimeError) {
+TEST(ResultTest, ValueOnFailureThrowsLogicError) {
   auto r = Result<int, SimpleError>::failure(SimpleError{1, "oops"});
-  EXPECT_THROW(static_cast<void>(r.value()), std::runtime_error);
+  EXPECT_THROW(static_cast<void>(r.value()), std::logic_error);
 }
 
-TEST(ResultTest, ConstValueOnFailureThrowsRuntimeError) {
+TEST(ResultTest, ConstValueOnFailureThrowsLogicError) {
   const auto r = Result<int, SimpleError>::failure(SimpleError{1, "oops"});
-  EXPECT_THROW(static_cast<void>(r.value()), std::runtime_error);
+  EXPECT_THROW(static_cast<void>(r.value()), std::logic_error);
 }
 
-TEST(ResultTest, MoveValueOnFailureThrowsRuntimeError) {
+TEST(ResultTest, MoveValueOnFailureThrowsLogicError) {
   auto r = Result<int, SimpleError>::failure(SimpleError{1, "oops"});
-  EXPECT_THROW(static_cast<void>(std::move(r).value()), std::runtime_error);
+  EXPECT_THROW(static_cast<void>(std::move(r).value()), std::logic_error);
 }
 
-TEST(ResultTest, ErrorOnSuccessThrowsRuntimeError) {
+TEST(ResultTest, ErrorOnSuccessThrowsLogicError) {
   auto r = Result<int, SimpleError>::success(42);
-  EXPECT_THROW(static_cast<void>(r.error()), std::runtime_error);
+  EXPECT_THROW(static_cast<void>(r.error()), std::logic_error);
 }
 
-TEST(ResultTest, ConstErrorOnSuccessThrowsRuntimeError) {
+TEST(ResultTest, ConstErrorOnSuccessThrowsLogicError) {
   const auto r = Result<int, SimpleError>::success(42);
-  EXPECT_THROW(static_cast<void>(r.error()), std::runtime_error);
+  EXPECT_THROW(static_cast<void>(r.error()), std::logic_error);
 }
 
-TEST(ResultTest, MoveErrorOnSuccessThrowsRuntimeError) {
+TEST(ResultTest, MoveErrorOnSuccessThrowsLogicError) {
   auto r = Result<int, SimpleError>::success(42);
-  EXPECT_THROW(static_cast<void>(std::move(r).error()), std::runtime_error);
+  EXPECT_THROW(static_cast<void>(std::move(r).error()), std::logic_error);
 }
 
 // ---------------------------------------------------------------------------
@@ -222,22 +222,22 @@ TEST(ResultVoidTest, FailureMoveError) {
 }
 
 // ---------------------------------------------------------------------------
-// Result<void, E> — precondition violations throw std::runtime_error
+// Result<void, E> — precondition violations throw std::logic_error
 // ---------------------------------------------------------------------------
 
-TEST(ResultVoidTest, ValueOnFailureThrowsRuntimeError) {
+TEST(ResultVoidTest, ValueOnFailureThrowsLogicError) {
   auto r = Result<void, SimpleError>::failure(SimpleError{1, "oops"});
-  EXPECT_THROW(r.value(), std::runtime_error);
+  EXPECT_THROW(r.value(), std::logic_error);
 }
 
-TEST(ResultVoidTest, ErrorOnSuccessThrowsRuntimeError) {
+TEST(ResultVoidTest, ErrorOnSuccessThrowsLogicError) {
   auto r = Result<void, SimpleError>::success();
-  EXPECT_THROW(static_cast<void>(r.error()), std::runtime_error);
+  EXPECT_THROW(static_cast<void>(r.error()), std::logic_error);
 }
 
-TEST(ResultVoidTest, MoveErrorOnSuccessThrowsRuntimeError) {
+TEST(ResultVoidTest, MoveErrorOnSuccessThrowsLogicError) {
   auto r = Result<void, SimpleError>::success();
-  EXPECT_THROW(static_cast<void>(std::move(r).error()), std::runtime_error);
+  EXPECT_THROW(static_cast<void>(std::move(r).error()), std::logic_error);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses a minor API change around `result.h` (dropping `noexcept` label)

Context:
- `Result` accessors were previously marked `noexcept`
- `clang-tidy` flagged this as inaccurate because `std::get` on a `std::variant` can throw a `std::bad_variant_access` if the type being accessed doesn't match the position

Considered alternatives:
- Keeping `noexcept` but using something like `std::get_if` (doesn't throw) --> declined due to dereferencing `nullptr` to maintain API signature
- Switching away from `std::variant` entirely to avoid to avoid this issue --> declined because it still doesn't address the root issue, which is accessing an error result on success and vice-versa
- Adjusting the API to return `std::optional` for accessors --> declined as too impactful to API, and conditionals `ok()` and `has_error()` already exist, would be redundant

Decision:
- `result.h` accessor methods drop `noexcept`
- Throw an exception with a message ourselves vs. going through `std::get` (users can't do much with a generic `std::bad_variant_access` exception with no message)

Impact:

This only affects users of `result.h` that were expecting an exception-free experience, which is negligible if not completely nonexistent at this point in the SDK maturity. In the existing version before this PR, the exception would still actually be thrown if the wrong type was accessed, even though it was marked `noexcept`.

## Testing

- Additional unit tests to cover this flow