### PR TITLE
Fix visibility for RPC

### DIFF
--- a/include/livekit/visibility.h
+++ b/include/livekit/visibility.h
@@ -20,7 +20,8 @@
 //
 // On Unix, the SDK is built with -fvisibility=hidden / -fvisibility-inlines-hidden,
 // so every symbol defaults to hidden. LIVEKIT_API re-exposes the symbol with
-// default visibility. Consumers see no annotation (just a normal declaration).
+// default visibility. Consumers also need default visibility so public RTTI
+// stays unique across shared-library boundaries.
 //
 // On Windows, the SDK is built without WINDOWS_EXPORT_ALL_SYMBOLS, so symbols
 // must be explicitly tagged with __declspec(dllexport) when building the SDK
@@ -34,11 +35,7 @@
 #define LIVEKIT_API __declspec(dllimport)
 #endif
 #else
-#if defined(LIVEKIT_BUILDING_SDK)
 #define LIVEKIT_API __attribute__((visibility("default")))
-#else
-#define LIVEKIT_API
-#endif
 #endif
 
 // LIVEKIT_INTERNAL_API marks a symbol that is NOT part of the public ABI but


### PR DESCRIPTION
@alan-george-lk summary of what's going on here:

- The RPC integration tests ensure a `livekit::RpcError` was caught in an error-condition test. This error extends `std::runtime_error`
- These tests were not enabled on Mac due to performance issues (speculative) with Mac GHA runners
  - This was missed during the initial visibility PR due to this
- Mac's `.dylib` type info behavior is different than on Linux, which does run and pass these integration tests
- Adjusting the visibility controls to default when not just building the livekit SDK (internal to the SDK build itself, not consumers or unit tests) fixes this visibility issue on the `livekit::RpcError` type so it can be correctly caught (on Mac)

This likely would have popped up in other ways as consumers used the SDK and wanted to inherit from our types (on Mac).