### PR TITLE
Forward Rust logs through FFI to SDK logger

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,9 +197,7 @@ jobs:
 
       # ---------- Run unit tests ----------
       - name: Run unit tests (Unix)
-        id: unit_tests
         if: runner.os != 'Windows'
-        continue-on-error: true
         timeout-minutes: 1
         shell: bash
         run: |
@@ -207,7 +205,6 @@ jobs:
             --gtest_output=xml:build-release/unit-test-results.xml
 
       - name: Run unit tests (Windows)
-        id: unit_tests
         if: runner.os == 'Windows'
         continue-on-error: true
         timeout-minutes: 1
@@ -283,12 +280,6 @@ jobs:
         if: failure() && matrix.e2e-testing
         shell: bash
         run: tail -n 500 livekit-server.log || true
-
-      - name: Check unit test result
-        if: always() && !cancelled() && steps.unit_tests.outcome == 'failure'
-        run: |
-          echo "::error::Unit tests failed"
-          exit 1
 
       # ---------- Upload results ----------
       - name: Upload test results

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -206,7 +206,6 @@ jobs:
 
       - name: Run unit tests (Windows)
         if: runner.os == 'Windows'
-        continue-on-error: true
         timeout-minutes: 1
         shell: pwsh
         run: |
@@ -215,7 +214,7 @@ jobs:
 
       # ---------- Install + start livekit-server for integration tests ----------
       - name: Install livekit-server and lk CLI
-        if: matrix.e2e-testing && !cancelled()
+        if: matrix.e2e-testing
         shell: bash
         run: |
           set -euxo pipefail
@@ -232,7 +231,7 @@ jobs:
           lk --version
 
       - name: Start livekit-server
-        if: matrix.e2e-testing && !cancelled()
+        if: matrix.e2e-testing
         shell: bash
         env:
           LIVEKIT_CONFIG: "enable_data_tracks: true"
@@ -256,7 +255,7 @@ jobs:
           exit 1
 
       - name: Run integration tests
-        if: matrix.e2e-testing && !cancelled()
+        if: matrix.e2e-testing
         timeout-minutes: 5
         shell: bash
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,7 +197,9 @@ jobs:
 
       # ---------- Run unit tests ----------
       - name: Run unit tests (Unix)
+        id: unit_tests
         if: runner.os != 'Windows'
+        continue-on-error: true
         timeout-minutes: 1
         shell: bash
         run: |
@@ -205,7 +207,9 @@ jobs:
             --gtest_output=xml:build-release/unit-test-results.xml
 
       - name: Run unit tests (Windows)
+        id: unit_tests
         if: runner.os == 'Windows'
+        continue-on-error: true
         timeout-minutes: 1
         shell: pwsh
         run: |
@@ -214,7 +218,7 @@ jobs:
 
       # ---------- Install + start livekit-server for integration tests ----------
       - name: Install livekit-server and lk CLI
-        if: matrix.e2e-testing
+        if: matrix.e2e-testing && !cancelled()
         shell: bash
         run: |
           set -euxo pipefail
@@ -231,7 +235,7 @@ jobs:
           lk --version
 
       - name: Start livekit-server
-        if: matrix.e2e-testing
+        if: matrix.e2e-testing && !cancelled()
         shell: bash
         env:
           LIVEKIT_CONFIG: "enable_data_tracks: true"
@@ -255,7 +259,7 @@ jobs:
           exit 1
 
       - name: Run integration tests
-        if: matrix.e2e-testing
+        if: matrix.e2e-testing && !cancelled()
         timeout-minutes: 5
         shell: bash
         env:
@@ -279,6 +283,12 @@ jobs:
         if: failure() && matrix.e2e-testing
         shell: bash
         run: tail -n 500 livekit-server.log || true
+
+      - name: Check unit test result
+        if: always() && !cancelled() && steps.unit_tests.outcome == 'failure'
+        run: |
+          echo "::error::Unit tests failed"
+          exit 1
 
       # ---------- Upload results ----------
       - name: Upload test results

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,11 +230,54 @@ with the same library loaded elsewhere in the host process.
 
 Code should be easy to read and understand. If a sacrifice is made for performance or readability, it should be documented.
 
-Adhere to clang-format checks configured in `.clang-format`. Run `./scripts/clang-format.sh` if needed to confirm code styling, and `./scripts/clang-format.sh --fix` to auto-format generated code created.
+#### Formatting (clang-format)
 
-### Static Analysis
+The repo enforces `.clang-format` in CI (see `.github/workflows/builds.yml` →
+`clang-format` job). Any divergence fails the build.
 
-Adhere to clang-tidy checks configured in `.clang-tidy`. Run `./scripts/clang-tidy.sh` if needed to confirm code quality.
+**Required workflow when generating or editing C/C++ code:**
+
+1. After completing a set of edits to any `.c`, `.cc`, `.cpp`, `.cxx`, `.h`,
+   `.hpp`, or `.hxx` file under `src/`, `include/`, or `benchmarks/`, run:
+
+   ```bash
+   ./scripts/clang-format.sh --fix <paths-you-edited>
+   ```
+
+   Pass the explicit paths so the run is fast; omit them only when doing a
+   sweep over the entire tree.
+2. If clang-format reports any rewrites, treat the rewritten contents as the
+   final state and re-read the file before doing any further edits to it.
+3. Do not commit, hand off, or declare a task complete with un-formatted
+   code. CI will reject it and the round-trip wastes time.
+
+`./scripts/clang-format.sh` (no `--fix`) runs in dry-run / `--Werror` mode and
+is what CI uses; it exits non-zero on any divergence.
+
+#### Static Analysis (clang-tidy)
+
+The repo enforces `.clang-tidy` in CI (see `.github/workflows/builds.yml` →
+`clang-tidy` job, run with `--fail-on-warning`). Any new warning fails the
+build.
+
+**Required workflow when generating or editing C/C++ code:**
+
+1. After substantive C/C++ edits — especially anything that adds new
+   identifiers, new enums, new public API, new free functions, or that
+   touches the FFI / threading boundary — run:
+
+   ```bash
+   ./scripts/clang-tidy.sh
+   ```
+
+   This requires a prior `./build.sh release` (or
+   `./build.sh release-tests` / `release-all`) so that
+   `build-release/compile_commands.json` and the generated protobuf headers
+   exist.
+2. Address any new findings introduced by your edits. Do not introduce new
+   `// NOLINT` suppressions without a one-line comment explaining *why*.
+3. Pre-existing findings in code you did not touch are out of scope unless
+   the user explicitly asks for a sweep.
 
 ## Dependencies
 

--- a/include/livekit/livekit.h
+++ b/include/livekit/livekit.h
@@ -43,7 +43,8 @@
 namespace livekit {
 
 /// The log sink to use for SDK messages.
-enum class LogSink {
+/// @deprecated Use livekit::setLogCallback instead to register a custom log callback
+enum class [[deprecated("Use livekit::setLogCallback instead to register a custom log callback")]] LogSink {
   /// Log messages to the console.
   kConsole = 0,
   /// Log messages to a callback function.
@@ -60,7 +61,18 @@ enum class LogSink {
 /// @param log_sink  The log sink to use for SDK messages (default: Console).
 /// @returns true if initialization happened on this call, false if it was
 ///          already initialized.
-LIVEKIT_API bool initialize(const LogLevel& level = LogLevel::Info, const LogSink& log_sink = LogSink::kConsole);
+/// @deprecated Use livekit::setLogCallback instead to register a custom log callback
+[[deprecated("Use livekit::setLogCallback instead to register a custom log callback")]] LIVEKIT_API bool initialize(
+    const LogLevel& level, const LogSink& log_sink);
+
+/// Initialize the LiveKit SDK.
+///
+/// This **must be the first LiveKit API called** in the process.
+/// It configures global SDK state.
+///
+/// @param level     Minimum log level for SDK messages (default: Info).
+///                  Use setLogLevel() to change at runtime.
+LIVEKIT_API bool initialize(const LogLevel& level = LogLevel::Info);
 
 /// Shut down the LiveKit SDK.
 ///

--- a/include/livekit/livekit.h
+++ b/include/livekit/livekit.h
@@ -16,28 +16,7 @@
 
 #pragma once
 
-#include "livekit/audio_frame.h"
-#include "livekit/audio_processing_module.h"
-#include "livekit/audio_source.h"
-#include "livekit/audio_stream.h"
-#include "livekit/build.h"
-#include "livekit/e2ee.h"
-#include "livekit/local_audio_track.h"
-#include "livekit/local_participant.h"
-#include "livekit/local_track_publication.h"
-#include "livekit/local_video_track.h"
 #include "livekit/logging.h"
-#include "livekit/participant.h"
-#include "livekit/remote_participant.h"
-#include "livekit/remote_track_publication.h"
-#include "livekit/room.h"
-#include "livekit/room_delegate.h"
-#include "livekit/room_event_types.h"
-#include "livekit/tracing.h"
-#include "livekit/track_publication.h"
-#include "livekit/video_frame.h"
-#include "livekit/video_source.h"
-#include "livekit/video_stream.h"
 #include "livekit/visibility.h"
 
 namespace livekit {

--- a/include/livekit/livekit.h
+++ b/include/livekit/livekit.h
@@ -16,7 +16,28 @@
 
 #pragma once
 
+#include "livekit/audio_frame.h"
+#include "livekit/audio_processing_module.h"
+#include "livekit/audio_source.h"
+#include "livekit/audio_stream.h"
+#include "livekit/build.h"
+#include "livekit/e2ee.h"
+#include "livekit/local_audio_track.h"
+#include "livekit/local_participant.h"
+#include "livekit/local_track_publication.h"
+#include "livekit/local_video_track.h"
 #include "livekit/logging.h"
+#include "livekit/participant.h"
+#include "livekit/remote_participant.h"
+#include "livekit/remote_track_publication.h"
+#include "livekit/room.h"
+#include "livekit/room_delegate.h"
+#include "livekit/room_event_types.h"
+#include "livekit/tracing.h"
+#include "livekit/track_publication.h"
+#include "livekit/video_frame.h"
+#include "livekit/video_source.h"
+#include "livekit/video_stream.h"
 #include "livekit/visibility.h"
 
 namespace livekit {

--- a/src/ffi_client.cpp
+++ b/src/ffi_client.cpp
@@ -276,10 +276,12 @@ extern "C" LIVEKIT_INTERNAL_API void LivekitFfiCallback(const uint8_t* buf, size
 
   // Forward any FFI logs to the SDK logger
   if (event.has_logs()) {
+    // Note: explicitly acquiring the logger here to avoid mutex acquires per-message
+    auto logger = detail::getLogger();
     for (const auto& rec : event.logs().records()) {
-      detail::forwardFfiLog(toSpdlogLevel(rec.level()), rec.target(), rec.message());
+      detail::forwardFfiLog(logger, toSpdlogLevel(rec.level()), rec.target(), rec.message());
     }
-    return; // No need to queue the logs
+    return; // No need to queue the log event from here
   }
 
   // We are in a unrecoverable state, terminate the process

--- a/src/ffi_client.cpp
+++ b/src/ffi_client.cpp
@@ -207,7 +207,36 @@ proto::FfiResponse FfiClient::sendRequest(const proto::FfiRequest& request) cons
   return response;
 }
 
+LogLevel fromProtoLogLevel(proto::LogLevel level) {
+  switch (level) {
+    case proto::LOG_ERROR:
+      return LogLevel::Error;
+    case proto::LOG_WARN:
+      return LogLevel::Warn;
+    case proto::LOG_INFO:
+      return LogLevel::Info;
+    case proto::LOG_DEBUG:
+      return LogLevel::Debug;
+    case proto::LOG_TRACE:
+      return LogLevel::Trace;
+    default:
+      return LogLevel::Info;
+  }
+}
+
+void forwardFfiLogBatch(const proto::LogBatch& batch) {
+  for (int i = 0; i < batch.records_size(); ++i) {
+    const auto& rec = batch.records(i);
+    detail::forwardFfiLog(fromProtoLogLevel(rec.level()), rec.target(), rec.message());
+  }
+}
+
 void FfiClient::PushEvent(const proto::FfiEvent& event) const {
+  // Forward any FFI logs to the SDK logger
+  if (event.has_logs()) {
+    forwardFfiLogBatch(event.logs());
+  }
+
   std::unique_ptr<PendingBase> to_complete;
   std::vector<Listener> listeners_copy;
   {

--- a/src/ffi_client.cpp
+++ b/src/ffi_client.cpp
@@ -269,7 +269,7 @@ void FfiClient::PushEvent(const proto::FfiEvent& event) const {
   }
 }
 
-LIVEKIT_INTERNAL_API void LivekitFfiCallback(const uint8_t* buf, size_t len) {
+extern "C" LIVEKIT_INTERNAL_API void LivekitFfiCallback(const uint8_t* buf, size_t len) {
   proto::FfiEvent event;
   event.ParseFromArray(buf,
                        static_cast<int>(len)); // TODO: this fixes for now, what if len exceeds int?

--- a/src/ffi_client.cpp
+++ b/src/ffi_client.cpp
@@ -17,6 +17,7 @@
 #include "ffi_client.h"
 
 #include <cassert>
+#include <csignal>
 
 #include "data_track.pb.h"
 #include "e2ee.pb.h"
@@ -207,7 +208,7 @@ proto::FfiResponse FfiClient::sendRequest(const proto::FfiRequest& request) cons
   return response;
 }
 
-LogLevel fromProtoLogLevel(proto::LogLevel level) {
+LogLevel toSpdlogLevel(proto::LogLevel level) {
   switch (level) {
     case proto::LOG_ERROR:
       return LogLevel::Error;
@@ -224,19 +225,7 @@ LogLevel fromProtoLogLevel(proto::LogLevel level) {
   }
 }
 
-void forwardFfiLogBatch(const proto::LogBatch& batch) {
-  for (int i = 0; i < batch.records_size(); ++i) {
-    const auto& rec = batch.records(i);
-    detail::forwardFfiLog(fromProtoLogLevel(rec.level()), rec.target(), rec.message());
-  }
-}
-
 void FfiClient::PushEvent(const proto::FfiEvent& event) const {
-  // Forward any FFI logs to the SDK logger
-  if (event.has_logs()) {
-    forwardFfiLogBatch(event.logs());
-  }
-
   std::unique_ptr<PendingBase> to_complete;
   std::vector<Listener> listeners_copy;
   {
@@ -268,10 +257,26 @@ void FfiClient::PushEvent(const proto::FfiEvent& event) const {
   }
 }
 
-void LivekitFfiCallback(const uint8_t* buf, size_t len) {
+LIVEKIT_INTERNAL_API void LivekitFfiCallback(const uint8_t* buf, size_t len) {
   proto::FfiEvent event;
   event.ParseFromArray(buf,
                        static_cast<int>(len)); // TODO: this fixes for now, what if len exceeds int?
+
+  // Forward any FFI logs to the SDK logger
+  if (event.has_logs()) {
+    for (const auto& rec : event.logs().records()) {
+      detail::forwardFfiLog(toSpdlogLevel(rec.level()), rec.target(), rec.message());
+    }
+    return; // No need to queue the logs
+  }
+
+  // We are in a unrecoverable state, terminate the process
+  // This is what Python does, may not make sense for C++
+  if (event.has_panic()) {
+    std::cerr << "FFI Panic: " << event.panic().message() << '\n';
+    std::raise(SIGTERM);
+    return;
+  }
 
   FfiClient::instance().PushEvent(event);
 }

--- a/src/ffi_client.h
+++ b/src/ffi_client.h
@@ -58,7 +58,7 @@ extern "C" void livekit_ffi_initialize(FfiCallbackFn cb, bool capture_logs, cons
 
 extern "C" void livekit_ffi_dispose();
 
-extern "C" void LivekitFfiCallback(const uint8_t* buf, size_t len);
+LIVEKIT_INTERNAL_API extern "C" void LivekitFfiCallback(const uint8_t* buf, size_t len);
 
 // The FfiClient is used to communicate with the FFI interface of the Rust SDK
 // We use the generated protocol messages to facilitate the communication.

--- a/src/ffi_client.h
+++ b/src/ffi_client.h
@@ -58,7 +58,7 @@ extern "C" void livekit_ffi_initialize(FfiCallbackFn cb, bool capture_logs, cons
 
 extern "C" void livekit_ffi_dispose();
 
-LIVEKIT_INTERNAL_API extern "C" void LivekitFfiCallback(const uint8_t* buf, size_t len);
+extern "C" LIVEKIT_INTERNAL_API void LivekitFfiCallback(const uint8_t* buf, size_t len);
 
 // The FfiClient is used to communicate with the FFI interface of the Rust SDK
 // We use the generated protocol messages to facilitate the communication.

--- a/src/livekit.cpp
+++ b/src/livekit.cpp
@@ -28,8 +28,6 @@ bool initialize(const LogLevel& level, const LogSink& log_sink) {
   return ffi_client.initialize(true);
 }
 
-bool isInitialized() { return FfiClient::instance().isInitialized(); }
-
 void shutdown() {
   FfiClient::instance().shutdown();
   detail::shutdownLogger();

--- a/src/livekit.cpp
+++ b/src/livekit.cpp
@@ -24,7 +24,7 @@ namespace livekit {
 bool initialize(const LogLevel& level, const LogSink& log_sink) {
   setLogLevel(level);
   auto& ffi_client = FfiClient::instance();
-  return ffi_client.initialize(log_sink == LogSink::kCallback);
+  return ffi_client.initialize(true);
 }
 
 void shutdown() {

--- a/src/livekit.cpp
+++ b/src/livekit.cpp
@@ -22,6 +22,11 @@
 namespace livekit {
 
 bool initialize(const LogLevel& level, const LogSink& log_sink) {
+  (void)log_sink;
+  return initialize(level);
+}
+
+bool initialize(const LogLevel& level) {
   // Initializes logger if singleton instance is not already initialized
   setLogLevel(level);
   auto& ffi_client = FfiClient::instance();

--- a/src/lk_log.h
+++ b/src/lk_log.h
@@ -35,13 +35,9 @@ LIVEKIT_INTERNAL_API std::shared_ptr<spdlog::logger> getLogger();
 LIVEKIT_INTERNAL_API void shutdownLogger();
 
 /// Forward a single record received from the Rust FFI log bridge into the
-/// SDK's spdlog sinks.  The supplied @p target is preserved as the
-/// `logger_name` exposed to any user-installed `setLogCallback`, allowing
-/// callers to distinguish between e.g. "livekit", "libwebrtc",
-/// "tokio-tungstenite", etc.
-///
-/// Filtering uses the same level set via `livekit::setLogLevel`.
-LIVEKIT_INTERNAL_API void forwardFfiLog(LogLevel level, const std::string& target, const std::string& message);
+/// supplied logger's spdlog sinks
+LIVEKIT_INTERNAL_API void forwardFfiLog(const std::shared_ptr<spdlog::logger>& logger, LogLevel level,
+                                        const std::string& target, const std::string& message);
 
 } // namespace livekit::detail
 

--- a/src/lk_log.h
+++ b/src/lk_log.h
@@ -19,7 +19,9 @@
 #include <spdlog/spdlog.h>
 
 #include <memory>
+#include <string>
 
+#include "livekit/logging.h"
 #include "livekit/visibility.h"
 
 namespace livekit::detail {
@@ -31,6 +33,15 @@ LIVEKIT_INTERNAL_API std::shared_ptr<spdlog::logger> getLogger();
 
 /// Tears down the spdlog logger. Called by livekit::shutdown().
 LIVEKIT_INTERNAL_API void shutdownLogger();
+
+/// Forward a single record received from the Rust FFI log bridge into the
+/// SDK's spdlog sinks.  The supplied @p target is preserved as the
+/// `logger_name` exposed to any user-installed `setLogCallback`, allowing
+/// callers to distinguish between e.g. "livekit", "libwebrtc",
+/// "tokio-tungstenite", etc.
+///
+/// Filtering uses the same level set via `livekit::setLogLevel`.
+LIVEKIT_INTERNAL_API void forwardFfiLog(LogLevel level, const std::string& target, const std::string& message);
 
 } // namespace livekit::detail
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -111,10 +111,8 @@ void shutdownLogger() {
   }
 }
 
-void forwardFfiLog(LogLevel level, const std::string& target, const std::string& message) {
-  // Snapshot the current logger via shared_ptr so that a concurrent
-  // setLogCallback() / shutdownLogger() cannot race with our sink iteration.
-  auto logger = getLogger();
+void forwardFfiLog(const std::shared_ptr<spdlog::logger>& logger, LogLevel level, const std::string& target,
+                   const std::string& message) {
   const auto spd_level = toSpdlogLevel(level);
   if (!logger->should_log(spd_level)) {
     return;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -111,6 +111,27 @@ void shutdownLogger() {
   }
 }
 
+void forwardFfiLog(LogLevel level, const std::string& target, const std::string& message) {
+  // Snapshot the current logger via shared_ptr so that a concurrent
+  // setLogCallback() / shutdownLogger() cannot race with our sink iteration.
+  auto logger = getLogger();
+  const auto spd_level = toSpdlogLevel(level);
+  if (!logger->should_log(spd_level)) {
+    return;
+  }
+
+  // Construct a log_msg directly so the Rust target survives as
+  // `logger_name`, instead of being collapsed into the single "livekit"
+  // logger name that spdlog would otherwise apply.
+  const spdlog::details::log_msg msg(spdlog::source_loc{}, spdlog::string_view_t{target.data(), target.size()},
+                                     spd_level, spdlog::string_view_t{message.data(), message.size()});
+  for (auto& sink : logger->sinks()) {
+    if (sink->should_log(spd_level)) {
+      sink->log(msg);
+    }
+  }
+}
+
 } // namespace detail
 
 void setLogLevel(LogLevel level) { detail::getLogger()->set_level(toSpdlogLevel(level)); }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -62,7 +62,6 @@ if(UNIT_TEST_SOURCES)
   target_link_libraries(livekit_unit_tests
     PRIVATE
       livekit
-      livekit_ffi
       spdlog::spdlog
       ${LIVEKIT_PROTOBUF_TARGET}
       GTest::gtest_main

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ if(UNIT_TEST_SOURCES)
   target_link_libraries(livekit_unit_tests
     PRIVATE
       livekit
+      livekit_ffi
       spdlog::spdlog
       ${LIVEKIT_PROTOBUF_TARGET}
       GTest::gtest_main

--- a/src/tests/unit/test_logging.cpp
+++ b/src/tests/unit/test_logging.cpp
@@ -18,6 +18,8 @@
 #include <livekit/livekit.h>
 
 #include <atomic>
+#include <chrono>
+#include <iostream>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -238,6 +240,124 @@ TEST_F(LoggingTest, ConcurrentSetLogLevelDoesNotCrash) {
   for (auto& th : threads) {
     th.join();
   }
+}
+
+// ---------------------------------------------------------------------------
+// Rust FFI -> C++ log forwarding
+// ---------------------------------------------------------------------------
+
+namespace {
+
+const char* logLevelName(LogLevel level) {
+  switch (level) {
+    case LogLevel::Trace:
+      return "TRACE";
+    case LogLevel::Debug:
+      return "DEBUG";
+    case LogLevel::Info:
+      return "INFO";
+    case LogLevel::Warn:
+      return "WARN";
+    case LogLevel::Error:
+      return "ERROR";
+    case LogLevel::Critical:
+      return "CRITICAL";
+    case LogLevel::Off:
+      return "OFF";
+  }
+  return "?";
+}
+
+} // namespace
+
+// Verifies that records emitted from the Rust FFI core surface through the
+// user-installed `setLogCallback` when the SDK is initialised with
+// `LogSink::kCallback`.  Without this wiring, log forwarding would silently
+// drop on the C++ side even though Rust is shipping `LogBatch` events over
+// the FFI bridge.
+//
+// This test does NOT use the `LoggingTest` fixture because that fixture
+// pre-initialises the SDK with `LogSink::kConsole` (i.e. `capture_logs=false`
+// on the Rust side).  Toggling capture_logs requires a fresh
+// `livekit::initialize()` call, so we manage the SDK lifecycle inline.
+TEST(FfiLoggingTest, RustLogsReachUserCallback) {
+  // Defensive: ensure the SDK is in a clean state in case this test runs
+  // after another test that left it initialised.  shutdown() is a no-op
+  // when not initialised.
+  livekit::shutdown();
+
+  struct Captured {
+    LogLevel level;
+    std::string logger_name;
+    std::string message;
+  };
+
+  std::mutex mtx;
+  std::vector<Captured> captured;
+
+  // Install the callback BEFORE initialize() so that the very first records
+  // emitted by Rust during FFI server setup (e.g. "initializing ffi server
+  // v...") are observed.  Each record is also echoed to std::cout for ad
+  // hoc inspection of what the Rust side is forwarding.
+  livekit::setLogCallback([&](LogLevel level, const std::string& logger_name, const std::string& message) {
+    const std::scoped_lock<std::mutex> lock(mtx);
+    std::cout << "[ffi-log] [" << logLevelName(level) << "] [" << logger_name << "] " << message << std::endl;
+    captured.push_back({level, logger_name, message});
+  });
+  livekit::setLogLevel(LogLevel::Trace);
+
+  ASSERT_TRUE(livekit::initialize(LogLevel::Trace, LogSink::kCallback));
+
+  // The Rust FFI logger batches records and flushes on the next iteration
+  // of its forwarding task.  Poll up to 5s for the well-known startup log
+  // to surface; this is generous to keep CI stable but typically resolves
+  // in well under a second.
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  bool found_rust_log = false;
+  while (std::chrono::steady_clock::now() < deadline) {
+    {
+      const std::scoped_lock<std::mutex> lock(mtx);
+      for (const auto& entry : captured) {
+        if (entry.message.find("initializing ffi server") != std::string::npos) {
+          found_rust_log = true;
+          break;
+        }
+      }
+    }
+    if (found_rust_log) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+
+  EXPECT_TRUE(found_rust_log) << "Expected the Rust 'initializing ffi server' log record to reach the C++ "
+                                 "setLogCallback via the FFI LogBatch bridge";
+
+  // Sanity-check that the forwarded record carries the Rust target as the
+  // logger name (i.e. NOT the C++-side "livekit" logger), proving that the
+  // bridge preserves provenance instead of collapsing every record into the
+  // SDK logger.
+  bool saw_non_livekit_logger = false;
+  {
+    const std::scoped_lock<std::mutex> lock(mtx);
+    for (const auto& entry : captured) {
+      if (entry.message.find("initializing ffi server") != std::string::npos) {
+        // Rust's `log::info!` in `livekit-ffi` reports a target rooted at
+        // `livekit_ffi::...`; we only require that *some* target was
+        // surfaced (any non-empty string), since the exact target string
+        // is owned by the Rust side and may evolve.
+        EXPECT_FALSE(entry.logger_name.empty()) << "FFI-forwarded log record should carry a target name";
+      }
+      if (!entry.logger_name.empty() && entry.logger_name != "livekit") {
+        saw_non_livekit_logger = true;
+      }
+    }
+  }
+  EXPECT_TRUE(saw_non_livekit_logger)
+      << "Expected at least one forwarded record to carry a Rust-side target distinct from the C++ 'livekit' logger";
+
+  livekit::setLogCallback(nullptr);
+  livekit::shutdown();
 }
 
 TEST_F(LoggingTest, ConcurrentLogEmissionDoesNotCrash) {

--- a/src/tests/unit/test_logging.cpp
+++ b/src/tests/unit/test_logging.cpp
@@ -15,11 +15,14 @@
  */
 
 #include <gtest/gtest.h>
+#include <livekit/audio_source.h>
 #include <livekit/livekit.h>
+#include <livekit/local_audio_track.h>
 
 #include <atomic>
 #include <chrono>
 #include <iostream>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -301,7 +304,7 @@ TEST(FfiLoggingTest, RustLogsReachUserCallback) {
   // hoc inspection of what the Rust side is forwarding.
   livekit::setLogCallback([&](LogLevel level, const std::string& logger_name, const std::string& message) {
     const std::scoped_lock<std::mutex> lock(mtx);
-    std::cout << "[ffi-log] [" << logLevelName(level) << "] [" << logger_name << "] " << message << std::endl;
+    std::cout << "[ffi-log] [" << logLevelName(level) << "] [" << logger_name << "] " << message << '\n';
     captured.push_back({level, logger_name, message});
   });
   livekit::setLogLevel(LogLevel::Trace);
@@ -358,6 +361,154 @@ TEST(FfiLoggingTest, RustLogsReachUserCallback) {
 
   livekit::setLogCallback(nullptr);
   livekit::shutdown();
+}
+
+TEST_F(LoggingTest, DummyRustTest) {
+  livekit::shutdown();
+  ASSERT_TRUE(livekit::initialize(LogLevel::Info));
+  LK_LOG_INFO("Hello from C++ SDK");
+
+  // The single FFI call here -- CreateAudioTrack -- is what crosses the FFI
+  // boundary into the `livekit` crate and triggers `LkRuntime::instance()`.
+  // The AudioSource ctor on its own does NOT instantiate LkRuntime; the
+  // track creation does.
+  {
+    auto audio_source = std::make_shared<AudioSource>(48000, 1);
+    auto track = LocalAudioTrack::createLocalAudioTrack("ffi-log-probe", audio_source);
+    ASSERT_NE(track, nullptr);
+    // Hold the handles briefly so any synchronous Rust-side debug logs land
+    // before the strong refs drop. The FFI logger flushes on a 1s interval,
+    // so this sleep does not gate observability -- it just keeps things tidy.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+}
+
+// Verifies that internal Rust logs originating BELOW the FFI layer (i.e. in
+// the `livekit` crate or in libwebrtc itself, not in `livekit-ffi`) propagate
+// through the FFI bridge into the user-installed `setLogCallback`.
+//
+// The sibling `RustLogsReachUserCallback` test only proves that the FFI layer
+// itself can forward its own startup log (`"initializing ffi server"`,
+// emitted from inside `livekit_ffi::server::FfiServer::setup`). That alone
+// does not prove that records emitted by deeper Rust crates -- which is what
+// shows up under `RUST_LOG=debug` as `[DEBUG libwebrtc] (...)` or as logs
+// targeted at `livekit::rtc_engine::*` -- also reach the user callback.
+//
+// Trigger path used here (fully in-process, no network):
+//
+//   C++  LocalAudioTrack::createLocalAudioTrack
+//     -> FFI request CreateAudioTrack
+//       -> Rust on_create_audio_track                     (livekit_ffi crate)
+//         -> LocalAudioTrack::create_audio_track          (livekit crate)
+//           -> LkRuntime::instance()
+//                -> log::debug!("LkRuntime::new()")
+//                   target = "livekit::rtc_engine::lk_runtime"
+//           -> PeerConnectionFactory::default()           (libwebrtc-rs)
+//                -> installs the libwebrtc LogSink that forwards every
+//                   internal libwebrtc message as `log::debug!(target:
+//                   "libwebrtc", ...)`.
+//
+// The libwebrtc-internal logs (e.g. the `text_pcap_packet_observer.cc` lines
+// the user sees under `RUST_LOG=debug`) generally fire only during real
+// signaling / ICE / SDP work, which requires a live LiveKit server and so
+// belong in integration tests. The deepest deterministic signal we can
+// trigger from a unit test is `LkRuntime::new()` -- which is still below the
+// FFI layer (it lives in the `livekit` Rust crate), so capturing it proves
+// the cross-crate forwarding works.
+//
+// Note about std::cout: the test installs a `setLogCallback`, which causes
+// the C++ logging layer to swap its spdlog sink set entirely for a callback
+// sink. While the callback is installed, no SDK log output reaches stderr or
+// stdout, so this test does NOT pollute GTest's console output (the only
+// echoes are the deliberate ad-hoc `[ffi-log]` prints below).
+TEST(FfiLoggingTest, LogsFromBelowFfiLayerReachUserCallback) {
+  // Defensive: start from a clean slate in case another test left the SDK
+  // initialised. shutdown() is a no-op when not initialised.
+  livekit::shutdown();
+
+  struct Captured {
+    LogLevel level;
+    std::string logger_name;
+    std::string message;
+  };
+
+  std::mutex mtx;
+  std::vector<Captured> captured;
+
+  // Install BEFORE initialize() so any startup records are observed too.
+  // livekit::setLogCallback([&](LogLevel level, const std::string& logger_name, const std::string& message) {
+  //   const std::scoped_lock<std::mutex> lock(mtx);
+  //   std::cout << "[ffi-log] [" << logLevelName(level) << "] [" << logger_name << "] " << message << '\n';
+  //   captured.push_back({level, logger_name, message});
+  // });
+
+  // Trace level so the FFI logger forwards everything
+  ASSERT_TRUE(livekit::initialize(LogLevel::Trace, LogSink::kCallback));
+
+  // The single FFI call here -- CreateAudioTrack -- is what crosses the FFI
+  // boundary into the `livekit` crate and triggers `LkRuntime::instance()`.
+  // The AudioSource ctor on its own does NOT instantiate LkRuntime; the
+  // track creation does.
+  {
+    auto audio_source = std::make_shared<AudioSource>(48000, 1);
+    auto track = LocalAudioTrack::createLocalAudioTrack("ffi-log-probe", audio_source);
+    ASSERT_NE(track, nullptr);
+    // Hold the handles briefly so any synchronous Rust-side debug logs land
+    // before the strong refs drop. The FFI logger flushes on a 1s interval,
+    // so this sleep does not gate observability -- it just keeps things tidy.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+
+  // The Rust FfiLogger batches log records and flushes on a 1-second tick
+  // (see livekit-ffi/src/server/logger.rs FLUSH_INTERVAL). Allow generous
+  // headroom for slow CI machines without making the test wall-time-heavy.
+  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+  bool found_below_ffi_log = false;
+  std::string matched_target;
+  std::string matched_message;
+  while (std::chrono::steady_clock::now() < deadline) {
+    {
+      const std::scoped_lock<std::mutex> lock(mtx);
+      for (const auto& entry : captured) {
+        // Targets demonstrably emitted from a layer BELOW livekit-ffi:
+        //   * "livekit::..."   -> livekit Rust crate (e.g. LkRuntime)
+        //   * "libwebrtc"      -> libwebrtc-rs LogSink shim
+        //   * "webrtc"/"webrtc::..." -> direct libwebrtc-rs targets, future-proofing
+        // We deliberately do NOT match "livekit_ffi" here -- that's the FFI
+        // layer itself and would not prove cross-crate propagation.
+        const auto& t = entry.logger_name;
+        const bool is_livekit_crate = t.rfind("livekit::", 0) == 0;
+        const bool is_libwebrtc = (t == "libwebrtc");
+        const bool is_webrtc_crate = (t == "webrtc") || t.rfind("webrtc::", 0) == 0;
+        if (is_livekit_crate || is_libwebrtc || is_webrtc_crate) {
+          found_below_ffi_log = true;
+          matched_target = t;
+          matched_message = entry.message;
+          break;
+        }
+      }
+    }
+    if (found_below_ffi_log) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
+
+  EXPECT_TRUE(found_below_ffi_log) << "Expected at least one log record from below the FFI layer "
+                                      "(target starting with 'livekit::', 'libwebrtc', or 'webrtc') to "
+                                      "reach the C++ setLogCallback. This validates the "
+                                      "C++ -> FFI -> livekit-rust -> log -> FFI -> C++ chain. If this "
+                                      "fires, it likely means either capture_logs=true is not being "
+                                      "honoured by the Rust FfiLogger, or the LkRuntime weak-ref is "
+                                      "still upgrading from a previous test (in which case run this "
+                                      "test in isolation: --gtest_filter=FfiLoggingTest.LogsFromBelowFfiLayer*).";
+
+  if (found_below_ffi_log) {
+    // Ad hoc breadcrumb so test logs make it obvious WHICH below-FFI record
+    // was the one that satisfied the assertion.
+    std::cout << "[ffi-log] matched below-FFI target='" << matched_target << "' message='" << matched_message << "'"
+              << '\n';
+  }
 }
 
 TEST_F(LoggingTest, ConcurrentLogEmissionDoesNotCrash) {

--- a/src/tests/unit/test_logging.cpp
+++ b/src/tests/unit/test_logging.cpp
@@ -21,6 +21,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <iostream>
 #include <memory>
 #include <mutex>
@@ -28,9 +29,19 @@
 #include <thread>
 #include <vector>
 
+#include "ffi_client.h"
+#include "livekit_ffi.h"
 #include "lk_log.h"
 
 namespace livekit::test {
+
+namespace {
+
+// FFI event entry point for tests. Forwards to the SDK handler so log batches
+// reach setLogCallback() the same way they do in production.
+extern "C" void testFfiCallback(const uint8_t* buf, size_t len) { LivekitFfiCallback(buf, len); }
+
+} // namespace
 
 class LoggingTest : public ::testing::Test {
 protected:
@@ -245,272 +256,6 @@ TEST_F(LoggingTest, ConcurrentSetLogLevelDoesNotCrash) {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Rust FFI -> C++ log forwarding
-// ---------------------------------------------------------------------------
-
-namespace {
-
-const char* logLevelName(LogLevel level) {
-  switch (level) {
-    case LogLevel::Trace:
-      return "TRACE";
-    case LogLevel::Debug:
-      return "DEBUG";
-    case LogLevel::Info:
-      return "INFO";
-    case LogLevel::Warn:
-      return "WARN";
-    case LogLevel::Error:
-      return "ERROR";
-    case LogLevel::Critical:
-      return "CRITICAL";
-    case LogLevel::Off:
-      return "OFF";
-  }
-  return "?";
-}
-
-} // namespace
-
-// Verifies that records emitted from the Rust FFI core surface through the
-// user-installed `setLogCallback` when the SDK is initialised with
-// `LogSink::kCallback`.  Without this wiring, log forwarding would silently
-// drop on the C++ side even though Rust is shipping `LogBatch` events over
-// the FFI bridge.
-//
-// This test does NOT use the `LoggingTest` fixture because that fixture
-// pre-initialises the SDK with `LogSink::kConsole` (i.e. `capture_logs=false`
-// on the Rust side).  Toggling capture_logs requires a fresh
-// `livekit::initialize()` call, so we manage the SDK lifecycle inline.
-TEST(FfiLoggingTest, RustLogsReachUserCallback) {
-  // Defensive: ensure the SDK is in a clean state in case this test runs
-  // after another test that left it initialised.  shutdown() is a no-op
-  // when not initialised.
-  livekit::shutdown();
-
-  struct Captured {
-    LogLevel level;
-    std::string logger_name;
-    std::string message;
-  };
-
-  std::mutex mtx;
-  std::vector<Captured> captured;
-
-  // Install the callback BEFORE initialize() so that the very first records
-  // emitted by Rust during FFI server setup (e.g. "initializing ffi server
-  // v...") are observed.  Each record is also echoed to std::cout for ad
-  // hoc inspection of what the Rust side is forwarding.
-  livekit::setLogCallback([&](LogLevel level, const std::string& logger_name, const std::string& message) {
-    const std::scoped_lock<std::mutex> lock(mtx);
-    std::cout << "[ffi-log] [" << logLevelName(level) << "] [" << logger_name << "] " << message << '\n';
-    captured.push_back({level, logger_name, message});
-  });
-  livekit::setLogLevel(LogLevel::Trace);
-
-  ASSERT_TRUE(livekit::initialize(LogLevel::Trace, LogSink::kCallback));
-
-  // The Rust FFI logger batches records and flushes on the next iteration
-  // of its forwarding task.  Poll up to 5s for the well-known startup log
-  // to surface; this is generous to keep CI stable but typically resolves
-  // in well under a second.
-  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-  bool found_rust_log = false;
-  while (std::chrono::steady_clock::now() < deadline) {
-    {
-      const std::scoped_lock<std::mutex> lock(mtx);
-      for (const auto& entry : captured) {
-        if (entry.message.find("initializing ffi server") != std::string::npos) {
-          found_rust_log = true;
-          break;
-        }
-      }
-    }
-    if (found_rust_log) {
-      break;
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  }
-
-  EXPECT_TRUE(found_rust_log) << "Expected the Rust 'initializing ffi server' log record to reach the C++ "
-                                 "setLogCallback via the FFI LogBatch bridge";
-
-  // Sanity-check that the forwarded record carries the Rust target as the
-  // logger name (i.e. NOT the C++-side "livekit" logger), proving that the
-  // bridge preserves provenance instead of collapsing every record into the
-  // SDK logger.
-  bool saw_non_livekit_logger = false;
-  {
-    const std::scoped_lock<std::mutex> lock(mtx);
-    for (const auto& entry : captured) {
-      if (entry.message.find("initializing ffi server") != std::string::npos) {
-        // Rust's `log::info!` in `livekit-ffi` reports a target rooted at
-        // `livekit_ffi::...`; we only require that *some* target was
-        // surfaced (any non-empty string), since the exact target string
-        // is owned by the Rust side and may evolve.
-        EXPECT_FALSE(entry.logger_name.empty()) << "FFI-forwarded log record should carry a target name";
-      }
-      if (!entry.logger_name.empty() && entry.logger_name != "livekit") {
-        saw_non_livekit_logger = true;
-      }
-    }
-  }
-  EXPECT_TRUE(saw_non_livekit_logger)
-      << "Expected at least one forwarded record to carry a Rust-side target distinct from the C++ 'livekit' logger";
-
-  livekit::setLogCallback(nullptr);
-  livekit::shutdown();
-}
-
-TEST_F(LoggingTest, DummyRustTest) {
-  livekit::shutdown();
-  ASSERT_TRUE(livekit::initialize(LogLevel::Info));
-  LK_LOG_INFO("Hello from C++ SDK");
-
-  // The single FFI call here -- CreateAudioTrack -- is what crosses the FFI
-  // boundary into the `livekit` crate and triggers `LkRuntime::instance()`.
-  // The AudioSource ctor on its own does NOT instantiate LkRuntime; the
-  // track creation does.
-  {
-    auto audio_source = std::make_shared<AudioSource>(48000, 1);
-    auto track = LocalAudioTrack::createLocalAudioTrack("ffi-log-probe", audio_source);
-    ASSERT_NE(track, nullptr);
-    // Hold the handles briefly so any synchronous Rust-side debug logs land
-    // before the strong refs drop. The FFI logger flushes on a 1s interval,
-    // so this sleep does not gate observability -- it just keeps things tidy.
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  }
-}
-
-// Verifies that internal Rust logs originating BELOW the FFI layer (i.e. in
-// the `livekit` crate or in libwebrtc itself, not in `livekit-ffi`) propagate
-// through the FFI bridge into the user-installed `setLogCallback`.
-//
-// The sibling `RustLogsReachUserCallback` test only proves that the FFI layer
-// itself can forward its own startup log (`"initializing ffi server"`,
-// emitted from inside `livekit_ffi::server::FfiServer::setup`). That alone
-// does not prove that records emitted by deeper Rust crates -- which is what
-// shows up under `RUST_LOG=debug` as `[DEBUG libwebrtc] (...)` or as logs
-// targeted at `livekit::rtc_engine::*` -- also reach the user callback.
-//
-// Trigger path used here (fully in-process, no network):
-//
-//   C++  LocalAudioTrack::createLocalAudioTrack
-//     -> FFI request CreateAudioTrack
-//       -> Rust on_create_audio_track                     (livekit_ffi crate)
-//         -> LocalAudioTrack::create_audio_track          (livekit crate)
-//           -> LkRuntime::instance()
-//                -> log::debug!("LkRuntime::new()")
-//                   target = "livekit::rtc_engine::lk_runtime"
-//           -> PeerConnectionFactory::default()           (libwebrtc-rs)
-//                -> installs the libwebrtc LogSink that forwards every
-//                   internal libwebrtc message as `log::debug!(target:
-//                   "libwebrtc", ...)`.
-//
-// The libwebrtc-internal logs (e.g. the `text_pcap_packet_observer.cc` lines
-// the user sees under `RUST_LOG=debug`) generally fire only during real
-// signaling / ICE / SDP work, which requires a live LiveKit server and so
-// belong in integration tests. The deepest deterministic signal we can
-// trigger from a unit test is `LkRuntime::new()` -- which is still below the
-// FFI layer (it lives in the `livekit` Rust crate), so capturing it proves
-// the cross-crate forwarding works.
-//
-// Note about std::cout: the test installs a `setLogCallback`, which causes
-// the C++ logging layer to swap its spdlog sink set entirely for a callback
-// sink. While the callback is installed, no SDK log output reaches stderr or
-// stdout, so this test does NOT pollute GTest's console output (the only
-// echoes are the deliberate ad-hoc `[ffi-log]` prints below).
-TEST(FfiLoggingTest, LogsFromBelowFfiLayerReachUserCallback) {
-  // Defensive: start from a clean slate in case another test left the SDK
-  // initialised. shutdown() is a no-op when not initialised.
-  livekit::shutdown();
-
-  struct Captured {
-    LogLevel level;
-    std::string logger_name;
-    std::string message;
-  };
-
-  std::mutex mtx;
-  std::vector<Captured> captured;
-
-  // Install BEFORE initialize() so any startup records are observed too.
-  // livekit::setLogCallback([&](LogLevel level, const std::string& logger_name, const std::string& message) {
-  //   const std::scoped_lock<std::mutex> lock(mtx);
-  //   std::cout << "[ffi-log] [" << logLevelName(level) << "] [" << logger_name << "] " << message << '\n';
-  //   captured.push_back({level, logger_name, message});
-  // });
-
-  // Trace level so the FFI logger forwards everything
-  ASSERT_TRUE(livekit::initialize(LogLevel::Trace, LogSink::kCallback));
-
-  // The single FFI call here -- CreateAudioTrack -- is what crosses the FFI
-  // boundary into the `livekit` crate and triggers `LkRuntime::instance()`.
-  // The AudioSource ctor on its own does NOT instantiate LkRuntime; the
-  // track creation does.
-  {
-    auto audio_source = std::make_shared<AudioSource>(48000, 1);
-    auto track = LocalAudioTrack::createLocalAudioTrack("ffi-log-probe", audio_source);
-    ASSERT_NE(track, nullptr);
-    // Hold the handles briefly so any synchronous Rust-side debug logs land
-    // before the strong refs drop. The FFI logger flushes on a 1s interval,
-    // so this sleep does not gate observability -- it just keeps things tidy.
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  }
-
-  // The Rust FfiLogger batches log records and flushes on a 1-second tick
-  // (see livekit-ffi/src/server/logger.rs FLUSH_INTERVAL). Allow generous
-  // headroom for slow CI machines without making the test wall-time-heavy.
-  const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-  bool found_below_ffi_log = false;
-  std::string matched_target;
-  std::string matched_message;
-  while (std::chrono::steady_clock::now() < deadline) {
-    {
-      const std::scoped_lock<std::mutex> lock(mtx);
-      for (const auto& entry : captured) {
-        // Targets demonstrably emitted from a layer BELOW livekit-ffi:
-        //   * "livekit::..."   -> livekit Rust crate (e.g. LkRuntime)
-        //   * "libwebrtc"      -> libwebrtc-rs LogSink shim
-        //   * "webrtc"/"webrtc::..." -> direct libwebrtc-rs targets, future-proofing
-        // We deliberately do NOT match "livekit_ffi" here -- that's the FFI
-        // layer itself and would not prove cross-crate propagation.
-        const auto& t = entry.logger_name;
-        const bool is_livekit_crate = t.rfind("livekit::", 0) == 0;
-        const bool is_libwebrtc = (t == "libwebrtc");
-        const bool is_webrtc_crate = (t == "webrtc") || t.rfind("webrtc::", 0) == 0;
-        if (is_livekit_crate || is_libwebrtc || is_webrtc_crate) {
-          found_below_ffi_log = true;
-          matched_target = t;
-          matched_message = entry.message;
-          break;
-        }
-      }
-    }
-    if (found_below_ffi_log) {
-      break;
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  }
-
-  EXPECT_TRUE(found_below_ffi_log) << "Expected at least one log record from below the FFI layer "
-                                      "(target starting with 'livekit::', 'libwebrtc', or 'webrtc') to "
-                                      "reach the C++ setLogCallback. This validates the "
-                                      "C++ -> FFI -> livekit-rust -> log -> FFI -> C++ chain. If this "
-                                      "fires, it likely means either capture_logs=true is not being "
-                                      "honoured by the Rust FfiLogger, or the LkRuntime weak-ref is "
-                                      "still upgrading from a previous test (in which case run this "
-                                      "test in isolation: --gtest_filter=FfiLoggingTest.LogsFromBelowFfiLayer*).";
-
-  if (found_below_ffi_log) {
-    // Ad hoc breadcrumb so test logs make it obvious WHICH below-FFI record
-    // was the one that satisfied the assertion.
-    std::cout << "[ffi-log] matched below-FFI target='" << matched_target << "' message='" << matched_message << "'"
-              << '\n';
-  }
-}
-
 TEST_F(LoggingTest, ConcurrentLogEmissionDoesNotCrash) {
   std::atomic<int> call_count{0};
 
@@ -537,6 +282,141 @@ TEST_F(LoggingTest, ConcurrentLogEmissionDoesNotCrash) {
   }
 
   EXPECT_GE(call_count.load(), kThreads * kIterations);
+}
+
+// ---------------------------------------------------------------------------
+// Rust FFI -> C++ log forwarding
+// ---------------------------------------------------------------------------
+
+namespace {
+
+// Utility function to convert LogLevel to a string for debug printing
+const char* logLevelName(LogLevel level) {
+  switch (level) {
+    case LogLevel::Trace:
+      return "TRACE";
+    case LogLevel::Debug:
+      return "DEBUG";
+    case LogLevel::Info:
+      return "INFO";
+    case LogLevel::Warn:
+      return "WARN";
+    case LogLevel::Error:
+      return "ERROR";
+    case LogLevel::Critical:
+      return "CRITICAL";
+    case LogLevel::Off:
+      return "OFF";
+  }
+  return "?";
+}
+
+} // namespace
+
+// Used by multiple tests
+struct Captured {
+  LogLevel level;
+  std::string logger_name;
+  std::string message;
+};
+
+TEST_F(LoggingTest, RustLogsAreForwarded) {
+  // User toggle for debugging this unit test
+  bool print_logs = true;
+
+  // Start from clean slate
+  livekit::shutdown();
+  std::mutex mut;
+  std::condition_variable cv;
+  std::vector<Captured> captured;
+  bool decode_error_received = false;
+
+  livekit::setLogLevel(LogLevel::Trace);
+  livekit::setLogCallback([&](LogLevel level, const std::string& logger_name, const std::string& message) {
+    const std::scoped_lock<std::mutex> lock(mut);
+    captured.push_back({level, logger_name, message});
+    if (print_logs) {
+      std::cout << "[Captured Rust log] [" << logLevelName(level) << "] [" << logger_name << "] " << message << '\n';
+    }
+
+    // Check for specific known error message for condition variable wait. Otherwise we have to sleep a second
+    // for the 1Hz flush interval, which slows this test down unnecessarily
+    if (level == LogLevel::Error && message.find("failed to decode request") != std::string::npos) {
+      decode_error_received = true;
+      cv.notify_one();
+    }
+  });
+
+  ASSERT_NO_THROW(livekit_ffi_initialize(testFfiCallback, true, "cpp-test", "1.0.0"));
+
+  // Induce a Rust-side error log via an invalid protobuf payload
+  {
+    std::vector<uint8_t> data(100);
+    const uint8_t* res_ptr = nullptr;
+    size_t res_len = 0;
+    const auto handle = livekit_ffi_request(data.data(), data.size(), &res_ptr, &res_len);
+    EXPECT_EQ(handle, INVALID_HANDLE);
+  }
+
+  // Wait for the error log to be captured
+  {
+    std::unique_lock<std::mutex> lock(mut);
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(1), [&] { return decode_error_received; }));
+  }
+
+  std::lock_guard<std::mutex> lock(mut);
+  // Ensure we got some logs -- not a specific value because that could change
+  ASSERT_GE(captured.size(), 1u);
+
+  std::size_t info_log_count = 0;
+  std::size_t warn_log_count = 0;
+  std::size_t debug_log_count = 0;
+  std::size_t error_log_count = 0;
+
+  bool found = false;
+  for (const auto& entry : captured) {
+    if (entry.level == LogLevel::Info) {
+      info_log_count++;
+    } else if (entry.level == LogLevel::Warn) {
+      warn_log_count++;
+    } else if (entry.level == LogLevel::Debug) {
+      debug_log_count++;
+    } else if (entry.level == LogLevel::Error) {
+      error_log_count++;
+    }
+  }
+
+  if (true) {
+    std::cout << "Info logs: " << info_log_count << '\n';
+    std::cout << "Warn logs: " << warn_log_count << '\n';
+    std::cout << "Debug logs: " << debug_log_count << '\n';
+    std::cout << "Error logs: " << error_log_count << '\n';
+  }
+
+  EXPECT_GT(info_log_count, 0);
+  EXPECT_GT(error_log_count, 0);
+
+  livekit_ffi_dispose();
+}
+
+TEST_F(LoggingTest, DummyRustTest) {
+  livekit::shutdown();
+  ASSERT_TRUE(livekit::initialize(LogLevel::Info));
+  LK_LOG_INFO("Hello from C++ SDK");
+
+  // The single FFI call here -- CreateAudioTrack -- is what crosses the FFI
+  // boundary into the `livekit` crate and triggers `LkRuntime::instance()`.
+  // The AudioSource ctor on its own does NOT instantiate LkRuntime;] the
+  // track creation does.
+  {
+    auto audio_source = std::make_shared<AudioSource>(48000, 1);
+    auto track = LocalAudioTrack::createLocalAudioTrack("ffi-log-probe", audio_source);
+    ASSERT_NE(track, nullptr);
+    // Hold the handles briefly so any synchronous Rust-side debug logs land
+    // before the strong refs drop. The FFI logger flushes on a 1s interval,
+    // so this sleep does not gate observability -- it just keeps things tidy.
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  }
 }
 
 } // namespace livekit::test

--- a/src/tests/unit/test_logging.cpp
+++ b/src/tests/unit/test_logging.cpp
@@ -41,6 +41,34 @@ namespace {
 // reach setLogCallback() the same way they do in production.
 extern "C" void testFfiCallback(const uint8_t* buf, size_t len) { LivekitFfiCallback(buf, len); }
 
+// Utility function to convert LogLevel to a string for debug printing
+const char* logLevelName(LogLevel level) {
+  switch (level) {
+    case LogLevel::Trace:
+      return "TRACE";
+    case LogLevel::Debug:
+      return "DEBUG";
+    case LogLevel::Info:
+      return "INFO";
+    case LogLevel::Warn:
+      return "WARN";
+    case LogLevel::Error:
+      return "ERROR";
+    case LogLevel::Critical:
+      return "CRITICAL";
+    case LogLevel::Off:
+      return "OFF";
+  }
+  return "?";
+}
+
+// Used to capture log records and verify them in tests
+struct LogRecord {
+  LogLevel level;
+  std::string logger_name;
+  std::string message;
+};
+
 } // namespace
 
 class LoggingTest : public ::testing::Test {
@@ -288,38 +316,6 @@ TEST_F(LoggingTest, ConcurrentLogEmissionDoesNotCrash) {
 // Rust FFI -> C++ log forwarding
 // ---------------------------------------------------------------------------
 
-namespace {
-
-// Utility function to convert LogLevel to a string for debug printing
-const char* logLevelName(LogLevel level) {
-  switch (level) {
-    case LogLevel::Trace:
-      return "TRACE";
-    case LogLevel::Debug:
-      return "DEBUG";
-    case LogLevel::Info:
-      return "INFO";
-    case LogLevel::Warn:
-      return "WARN";
-    case LogLevel::Error:
-      return "ERROR";
-    case LogLevel::Critical:
-      return "CRITICAL";
-    case LogLevel::Off:
-      return "OFF";
-  }
-  return "?";
-}
-
-} // namespace
-
-// Used by multiple tests
-struct Captured {
-  LogLevel level;
-  std::string logger_name;
-  std::string message;
-};
-
 TEST_F(LoggingTest, RustLogsAreForwarded) {
   // User toggle for debugging this unit test
   bool print_logs = true;
@@ -328,7 +324,7 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
   livekit::shutdown();
   std::mutex mut;
   std::condition_variable cv;
-  std::vector<Captured> captured;
+  std::vector<LogRecord> captured;
   bool decode_error_received = false;
 
   livekit::setLogLevel(LogLevel::Trace);

--- a/src/tests/unit/test_logging.cpp
+++ b/src/tests/unit/test_logging.cpp
@@ -23,7 +23,6 @@
 #include <chrono>
 #include <condition_variable>
 #include <iostream>
-#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -392,6 +391,43 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
   EXPECT_GT(info_log_count, 0u);
   EXPECT_GT(warn_log_count, 0u);
   EXPECT_GT(error_log_count, 0u);
+
+  FfiClient::instance().shutdown();
+}
+
+TEST_F(LoggingTest, RustLogsAreSuppressedWhenOff) {
+  livekit::shutdown();
+
+  std::mutex mut;
+  std::condition_variable cv;
+  std::size_t log_count = 0;
+
+  livekit::setLogLevel(LogLevel::Off);
+  livekit::setLogCallback([&](LogLevel, const std::string&, const std::string&) {
+    const std::scoped_lock<std::mutex> lock(mut);
+    ++log_count;
+    cv.notify_all();
+  });
+
+  // Throw in a local SDK log for good measure
+  LK_LOG_INFO("Should not log");
+
+  // Same Rust-side stimuli as RustLogsAreForwarded, but the C++ logger should filter them all.
+  ASSERT_TRUE(FfiClient::instance().initialize(true));
+  sendFailedConnectRequest();
+  ASSERT_THROW(sendInvalidFfiRequest(), std::runtime_error);
+  {
+    const FfiHandle invalid_handle(12345);
+    (void)invalid_handle;
+  }
+
+  {
+    std::unique_lock<std::mutex> lock(mut);
+    // Until Rust FFI supports log flushing, we need a timeout like this to ensure no logs are
+    // forwarded within the 1Hz threshold
+    EXPECT_FALSE(cv.wait_for(lock, std::chrono::seconds(2), [&] { return log_count > 0; }));
+    EXPECT_EQ(log_count, 0u);
+  }
 
   FfiClient::instance().shutdown();
 }

--- a/src/tests/unit/test_logging.cpp
+++ b/src/tests/unit/test_logging.cpp
@@ -101,14 +101,8 @@ TEST_F(LoggingTest, DefaultLogLevelIsInfo) { EXPECT_EQ(livekit::getLogLevel(), L
 // ---------------------------------------------------------------------------
 
 TEST_F(LoggingTest, CallbackReceivesLogMessages) {
-  struct Captured {
-    LogLevel level;
-    std::string logger_name;
-    std::string message;
-  };
-
   std::mutex mtx;
-  std::vector<Captured> captured;
+  std::vector<LogRecord> captured;
 
   livekit::setLogCallback([&](LogLevel level, const std::string& logger_name, const std::string& message) {
     std::lock_guard<std::mutex> lock(mtx);
@@ -313,34 +307,33 @@ TEST_F(LoggingTest, ConcurrentLogEmissionDoesNotCrash) {
 // Rust FFI -> C++ log forwarding
 // ---------------------------------------------------------------------------
 
-TEST_F(LoggingTest, RustLogsAreForwarded) {
-  // User toggle for debugging this unit test
-  // Prints all the forwarded logs to the console
-  bool print_logs = false;
+// Starts an async room connect; livekit-api logs INFO ("connecting to ...") and the attempt
+// eventually fails with ERROR.
+void sendFailedConnectRequest() {
+  proto::FfiRequest req;
+  auto* connect = req.mutable_connect();
+  connect->set_url("ws://127.0.0.1:7880");
+  // JWT-shaped token (format only); connection is expected to fail.
+  connect->set_token("eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjB9.x");
+  connect->mutable_options()->set_connect_timeout_ms(500);
+  FfiClient::instance().sendRequest(req);
+}
 
-  // Start from clean slate
+TEST_F(LoggingTest, RustLogsAreForwarded) {
+  constexpr bool kPrintLogs = false;
+
   livekit::shutdown();
 
   std::mutex mut;
-  std::vector<LogRecord> captured;
   std::condition_variable cv;
-
-  // Used to track how many logs of each level have been forwarded,
-  // and used by the condition variable to immedtiate unblock once the buffered logs are consumed
   std::size_t info_log_count = 0;
   std::size_t warn_log_count = 0;
   std::size_t debug_log_count = 0;
   std::size_t error_log_count = 0;
 
-  const auto all_rust_logs_received = [&] {
-    return info_log_count > 0 && debug_log_count > 0 && warn_log_count > 0 && error_log_count > 0;
-  };
-
-  livekit::setLogLevel(LogLevel::Trace);
   livekit::setLogCallback([&](LogLevel level, const std::string& logger_name, const std::string& message) {
     const std::scoped_lock<std::mutex> lock(mut);
-    captured.push_back({level, logger_name, message});
-    if (print_logs) {
+    if (kPrintLogs) {
       std::cout << "[Forwarded Rust log] [" << logLevelName(level) << "] [" << logger_name << "] " << message << '\n';
     }
 
@@ -360,70 +353,51 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
       default:
         break;
     }
-
-    if (all_rust_logs_received()) {
-      cv.notify_one();
-    }
+    cv.notify_all();
   });
 
-  // Induce a Rust-side debug level log via FFI initialization.
+  const auto wait_for = [&](const auto& predicate) {
+    std::unique_lock<std::mutex> lock(mut);
+    return cv.wait_for(lock, std::chrono::seconds(2), predicate);
+  };
+
+  // Stage 1: Error — only error-level Rust logs should be forwarded.
+  livekit::setLogLevel(LogLevel::Error);
   ASSERT_TRUE(FfiClient::instance().initialize(true));
+  sendFailedConnectRequest();
+  ASSERT_TRUE(wait_for([&] { return error_log_count > 0; }));
+  EXPECT_GT(error_log_count, 0u);
+  EXPECT_EQ(debug_log_count, 0u);
+  EXPECT_EQ(info_log_count, 0u);
+  EXPECT_EQ(warn_log_count, 0u);
 
-  // Induce Rust-side info level log
-  // Starts an async room connect so livekit-api logs at INFO ("connecting to ...") before the
-  // attempt fails
-  proto::FfiRequest req;
-  auto* connect = req.mutable_connect();
-  connect->set_url("ws://127.0.0.1:7880");
-  // JWT-shaped token (format only); connection is expected to fail.
-  connect->set_token("eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjB9.x");
-  connect->mutable_options()->set_connect_timeout_ms(500);
-  ASSERT_NO_THROW(FfiClient::instance().sendRequest(req));
-
-  // Induce a Rust-side warning via dropping an invalid handle.
+  // Stage 2: Warn — invalid handle drop produces a warning.
+  livekit::setLogLevel(LogLevel::Warn);
+  const std::size_t error_before_warn = error_log_count;
   {
     const FfiHandle invalid_handle(12345);
     (void)invalid_handle;
   }
+  ASSERT_TRUE(wait_for([&] { return warn_log_count > 0; }));
+  EXPECT_GT(warn_log_count, 0u);
+  EXPECT_GE(error_log_count, error_before_warn);
 
-  {
-    std::unique_lock<std::mutex> lock(mut);
-    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(2), all_rust_logs_received));
-  }
+  // Stage 3: Info — connect logs "connecting to ..." at INFO before failing.
+  livekit::setLogLevel(LogLevel::Info);
+  sendFailedConnectRequest();
+  ASSERT_TRUE(wait_for([&] { return info_log_count > 0; }));
+  EXPECT_GT(info_log_count, 0u);
 
-  if (print_logs) {
-    std::cout << "Info logs: " << info_log_count << '\n';
-    std::cout << "Warn logs: " << warn_log_count << '\n';
-    std::cout << "Debug logs: " << debug_log_count << '\n';
-    std::cout << "Error logs: " << error_log_count << '\n';
-  }
+  // Stage 4: Debug — re-init FFI to emit initialization debug logs.
+  livekit::setLogLevel(LogLevel::Debug);
+  FfiClient::instance().shutdown();
+  ASSERT_TRUE(FfiClient::instance().initialize(true));
+  ASSERT_TRUE(wait_for([&] { return debug_log_count > 0; }));
+  EXPECT_GT(debug_log_count, 0u);
 
-  EXPECT_GT(debug_log_count, 0);
-  EXPECT_GT(info_log_count, 0);
-  EXPECT_GT(warn_log_count, 0);
-  EXPECT_GT(error_log_count, 0);
+  // Trace is not logged in Rust at time of writing
 
   FfiClient::instance().shutdown();
-}
-
-TEST_F(LoggingTest, DummyRustTest) {
-  livekit::shutdown();
-  ASSERT_TRUE(livekit::initialize(LogLevel::Info));
-  LK_LOG_INFO("Hello from C++ SDK");
-
-  // The single FFI call here -- CreateAudioTrack -- is what crosses the FFI
-  // boundary into the `livekit` crate and triggers `LkRuntime::instance()`.
-  // The AudioSource ctor on its own does NOT instantiate LkRuntime;] the
-  // track creation does.
-  {
-    auto audio_source = std::make_shared<AudioSource>(48000, 1);
-    auto track = LocalAudioTrack::createLocalAudioTrack("ffi-log-probe", audio_source);
-    ASSERT_NE(track, nullptr);
-    // Hold the handles briefly so any synchronous Rust-side debug logs land
-    // before the strong refs drop. The FFI logger flushes on a 1s interval,
-    // so this sleep does not gate observability -- it just keeps things tidy.
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-  }
 }
 
 } // namespace livekit::test

--- a/src/tests/unit/test_logging.cpp
+++ b/src/tests/unit/test_logging.cpp
@@ -322,29 +322,63 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
 
   // Start from clean slate
   livekit::shutdown();
+
   std::mutex mut;
-  std::condition_variable cv;
   std::vector<LogRecord> captured;
-  bool error_received = false;
+  std::condition_variable cv;
+
+  // Used to track how many logs of each level have been forwarded,
+  // and used by the condition variable to immedtiate unblock once the buffered logs are consumed
+  std::size_t info_log_count = 0;
+  std::size_t warn_log_count = 0;
+  std::size_t debug_log_count = 0;
+  std::size_t error_log_count = 0;
+
+  const auto required_rust_logs_received = [&] {
+    return debug_log_count > 0 && warn_log_count > 0 && error_log_count > 0;
+  };
 
   livekit::setLogLevel(LogLevel::Trace);
   livekit::setLogCallback([&](LogLevel level, const std::string& logger_name, const std::string& message) {
     const std::scoped_lock<std::mutex> lock(mut);
     captured.push_back({level, logger_name, message});
     if (print_logs) {
-      std::cout << "[Captured Rust log] [" << logLevelName(level) << "] [" << logger_name << "] " << message << '\n';
+      std::cout << "[Forwarded Rust log] [" << logLevelName(level) << "] [" << logger_name << "] " << message << '\n';
     }
 
-    // Wake as soon as any error is forwarded so we avoid waiting for the 1Hz flush interval.
-    if (level == LogLevel::Error) {
-      error_received = true;
+    switch (level) {
+      case LogLevel::Info:
+        ++info_log_count;
+        break;
+      case LogLevel::Warn:
+        ++warn_log_count;
+        break;
+      case LogLevel::Debug:
+        ++debug_log_count;
+        break;
+      case LogLevel::Error:
+        ++error_log_count;
+        break;
+      default:
+        break;
+    }
+
+    // Wake once init (debug), invalid handle (warn), and bad request (error) have all been forwarded.
+    if (required_rust_logs_received()) {
       cv.notify_one();
     }
   });
 
+  // Induce a Rust-side debug level log
+  // Via FFI initialization messages
   ASSERT_NO_THROW(livekit_ffi_initialize(testFfiCallback, true, "cpp-test", "1.0.0"));
 
-  // Induce a Rust-side error log via an invalid protobuf payload
+  // Induce a Rust-wise warning level log
+  // Via dropping an invalid handle
+  livekit_ffi_drop_handle(12345);
+
+  // Induce a Rust-side error level log
+  // Via an invalid protobuf payload
   {
     std::vector<uint8_t> data(100);
     const uint8_t* res_ptr = nullptr;
@@ -353,41 +387,20 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
     EXPECT_EQ(handle, INVALID_HANDLE);
   }
 
-  // Wait for the error log to be captured
+  // Wait for the required logs to be forwarded
   {
     std::unique_lock<std::mutex> lock(mut);
-    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(1), [&] { return error_received; }));
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(1), required_rust_logs_received));
   }
 
-  std::lock_guard<std::mutex> lock(mut);
-  // Ensure we got some logs -- not a specific value because that could change
-  ASSERT_GE(captured.size(), 1u);
-
-  std::size_t info_log_count = 0;
-  std::size_t warn_log_count = 0;
-  std::size_t debug_log_count = 0;
-  std::size_t error_log_count = 0;
-
-  bool found = false;
-  for (const auto& entry : captured) {
-    if (entry.level == LogLevel::Info) {
-      info_log_count++;
-    } else if (entry.level == LogLevel::Warn) {
-      warn_log_count++;
-    } else if (entry.level == LogLevel::Debug) {
-      debug_log_count++;
-    } else if (entry.level == LogLevel::Error) {
-      error_log_count++;
-    }
-  }
-
-  if (true) {
+  if (print_logs) {
     std::cout << "Info logs: " << info_log_count << '\n';
     std::cout << "Warn logs: " << warn_log_count << '\n';
     std::cout << "Debug logs: " << debug_log_count << '\n';
     std::cout << "Error logs: " << error_log_count << '\n';
   }
 
+  EXPECT_GT(warn_log_count, 0);
   EXPECT_GT(debug_log_count, 0);
   EXPECT_GT(error_log_count, 0);
 

--- a/src/tests/unit/test_logging.cpp
+++ b/src/tests/unit/test_logging.cpp
@@ -310,8 +310,7 @@ TEST_F(LoggingTest, ConcurrentLogEmissionDoesNotCrash) {
 // Rust FFI -> C++ log forwarding
 // ---------------------------------------------------------------------------
 
-// Starts an async room connect; livekit-api logs INFO ("connecting to ...") and the attempt
-// eventually fails with ERROR.
+// Starts an async room connect so livekit-api logs INFO ("connecting to ...").
 void sendFailedConnectRequest() {
   proto::FfiRequest req;
   auto* connect = req.mutable_connect();
@@ -320,6 +319,14 @@ void sendFailedConnectRequest() {
   connect->set_token("eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjB9.x");
   connect->mutable_options()->set_connect_timeout_ms(500);
   FfiClient::instance().sendRequest(req);
+}
+
+void sendInvalidFfiRequest() {
+  proto::FfiRequest req;
+  auto* set_subscribed = req.mutable_set_subscribed();
+  set_subscribed->set_subscribe(true);
+  set_subscribed->set_publication_handle(12345);
+  (void)FfiClient::instance().sendRequest(req);
 }
 
 TEST_F(LoggingTest, RustLogsAreForwarded) {
@@ -367,9 +374,10 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
     }
   });
 
-  // Stimuli: init (debug), connect (info + error), invalid handle drop (warn).
+  // Stimuli: init (debug), connect (info), invalid request (error), invalid handle drop (warn).
   ASSERT_TRUE(FfiClient::instance().initialize(true));
   sendFailedConnectRequest();
+  ASSERT_THROW(sendInvalidFfiRequest(), std::runtime_error);
   {
     const FfiHandle invalid_handle(12345);
     (void)invalid_handle;

--- a/src/tests/unit/test_logging.cpp
+++ b/src/tests/unit/test_logging.cpp
@@ -334,6 +334,11 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
   std::size_t debug_log_count = 0;
   std::size_t error_log_count = 0;
 
+  const auto all_rust_logs_received = [&] {
+    return info_log_count > 0 && debug_log_count > 0 && warn_log_count > 0 && error_log_count > 0;
+  };
+
+  livekit::setLogLevel(LogLevel::Trace);
   livekit::setLogCallback([&](LogLevel level, const std::string& logger_name, const std::string& message) {
     const std::scoped_lock<std::mutex> lock(mut);
     if (kPrintLogs) {
@@ -356,49 +361,29 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
       default:
         break;
     }
-    cv.notify_all();
+
+    if (all_rust_logs_received()) {
+      cv.notify_all();
+    }
   });
 
-  const auto wait_for = [&](const auto& predicate) {
-    std::unique_lock<std::mutex> lock(mut);
-    return cv.wait_for(lock, std::chrono::seconds(2), predicate);
-  };
-
-  // Stage 1: Error — only error-level Rust logs should be forwarded.
-  livekit::setLogLevel(LogLevel::Error);
+  // Stimuli: init (debug), connect (info + error), invalid handle drop (warn).
   ASSERT_TRUE(FfiClient::instance().initialize(true));
   sendFailedConnectRequest();
-  ASSERT_TRUE(wait_for([&] { return error_log_count > 0; }));
-  EXPECT_GT(error_log_count, 0u);
-  EXPECT_EQ(debug_log_count, 0u);
-  EXPECT_EQ(info_log_count, 0u);
-  EXPECT_EQ(warn_log_count, 0u);
-
-  // Stage 2: Warn — invalid handle drop produces a warning.
-  livekit::setLogLevel(LogLevel::Warn);
-  const std::size_t error_before_warn = error_log_count;
   {
     const FfiHandle invalid_handle(12345);
     (void)invalid_handle;
   }
-  ASSERT_TRUE(wait_for([&] { return warn_log_count > 0; }));
-  EXPECT_GT(warn_log_count, 0u);
-  EXPECT_GE(error_log_count, error_before_warn);
 
-  // Stage 3: Info — connect logs "connecting to ..." at INFO before failing.
-  livekit::setLogLevel(LogLevel::Info);
-  sendFailedConnectRequest();
-  ASSERT_TRUE(wait_for([&] { return info_log_count > 0; }));
-  EXPECT_GT(info_log_count, 0u);
+  {
+    std::unique_lock<std::mutex> lock(mut);
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(3), all_rust_logs_received));
+  }
 
-  // Stage 4: Debug — re-init FFI to emit initialization debug logs.
-  livekit::setLogLevel(LogLevel::Debug);
-  FfiClient::instance().shutdown();
-  ASSERT_TRUE(FfiClient::instance().initialize(true));
-  ASSERT_TRUE(wait_for([&] { return debug_log_count > 0; }));
   EXPECT_GT(debug_log_count, 0u);
-
-  // Trace is not logged in Rust at time of writing
+  EXPECT_GT(info_log_count, 0u);
+  EXPECT_GT(warn_log_count, 0u);
+  EXPECT_GT(error_log_count, 0u);
 
   FfiClient::instance().shutdown();
 }

--- a/src/tests/unit/test_logging.cpp
+++ b/src/tests/unit/test_logging.cpp
@@ -325,7 +325,7 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
   std::mutex mut;
   std::condition_variable cv;
   std::vector<LogRecord> captured;
-  bool decode_error_received = false;
+  bool error_received = false;
 
   livekit::setLogLevel(LogLevel::Trace);
   livekit::setLogCallback([&](LogLevel level, const std::string& logger_name, const std::string& message) {
@@ -335,10 +335,9 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
       std::cout << "[Captured Rust log] [" << logLevelName(level) << "] [" << logger_name << "] " << message << '\n';
     }
 
-    // Check for specific known error message for condition variable wait. Otherwise we have to sleep a second
-    // for the 1Hz flush interval, which slows this test down unnecessarily
-    if (level == LogLevel::Error && message.find("failed to decode request") != std::string::npos) {
-      decode_error_received = true;
+    // Wake as soon as any error is forwarded so we avoid waiting for the 1Hz flush interval.
+    if (level == LogLevel::Error) {
+      error_received = true;
       cv.notify_one();
     }
   });
@@ -357,7 +356,7 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
   // Wait for the error log to be captured
   {
     std::unique_lock<std::mutex> lock(mut);
-    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(1), [&] { return decode_error_received; }));
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(1), [&] { return error_received; }));
   }
 
   std::lock_guard<std::mutex> lock(mut);
@@ -389,7 +388,7 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
     std::cout << "Error logs: " << error_log_count << '\n';
   }
 
-  EXPECT_GT(info_log_count, 0);
+  EXPECT_GT(debug_log_count, 0);
   EXPECT_GT(error_log_count, 0);
 
   livekit_ffi_dispose();

--- a/src/tests/unit/test_logging.cpp
+++ b/src/tests/unit/test_logging.cpp
@@ -29,17 +29,14 @@
 #include <thread>
 #include <vector>
 
+#include "ffi.pb.h"
 #include "ffi_client.h"
-#include "livekit_ffi.h"
+#include "livekit/ffi_handle.h"
 #include "lk_log.h"
 
 namespace livekit::test {
 
 namespace {
-
-// FFI event entry point for tests. Forwards to the SDK handler so log batches
-// reach setLogCallback() the same way they do in production.
-extern "C" void testFfiCallback(const uint8_t* buf, size_t len) { LivekitFfiCallback(buf, len); }
 
 // Utility function to convert LogLevel to a string for debug printing
 const char* logLevelName(LogLevel level) {
@@ -318,7 +315,8 @@ TEST_F(LoggingTest, ConcurrentLogEmissionDoesNotCrash) {
 
 TEST_F(LoggingTest, RustLogsAreForwarded) {
   // User toggle for debugging this unit test
-  bool print_logs = true;
+  // Prints all the forwarded logs to the console
+  bool print_logs = false;
 
   // Start from clean slate
   livekit::shutdown();
@@ -334,8 +332,8 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
   std::size_t debug_log_count = 0;
   std::size_t error_log_count = 0;
 
-  const auto required_rust_logs_received = [&] {
-    return debug_log_count > 0 && warn_log_count > 0 && error_log_count > 0;
+  const auto all_rust_logs_received = [&] {
+    return info_log_count > 0 && debug_log_count > 0 && warn_log_count > 0 && error_log_count > 0;
   };
 
   livekit::setLogLevel(LogLevel::Trace);
@@ -363,34 +361,34 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
         break;
     }
 
-    // Wake once init (debug), invalid handle (warn), and bad request (error) have all been forwarded.
-    if (required_rust_logs_received()) {
+    if (all_rust_logs_received()) {
       cv.notify_one();
     }
   });
 
-  // Induce a Rust-side debug level log
-  // Via FFI initialization messages
-  ASSERT_NO_THROW(livekit_ffi_initialize(testFfiCallback, true, "cpp-test", "1.0.0"));
+  // Induce a Rust-side debug level log via FFI initialization.
+  ASSERT_TRUE(FfiClient::instance().initialize(true));
 
-  // Induce a Rust-wise warning level log
-  // Via dropping an invalid handle
-  livekit_ffi_drop_handle(12345);
+  // Induce Rust-side info level log
+  // Starts an async room connect so livekit-api logs at INFO ("connecting to ...") before the
+  // attempt fails
+  proto::FfiRequest req;
+  auto* connect = req.mutable_connect();
+  connect->set_url("ws://127.0.0.1:7880");
+  // JWT-shaped token (format only); connection is expected to fail.
+  connect->set_token("eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjB9.x");
+  connect->mutable_options()->set_connect_timeout_ms(500);
+  ASSERT_NO_THROW(FfiClient::instance().sendRequest(req));
 
-  // Induce a Rust-side error level log
-  // Via an invalid protobuf payload
+  // Induce a Rust-side warning via dropping an invalid handle.
   {
-    std::vector<uint8_t> data(100);
-    const uint8_t* res_ptr = nullptr;
-    size_t res_len = 0;
-    const auto handle = livekit_ffi_request(data.data(), data.size(), &res_ptr, &res_len);
-    EXPECT_EQ(handle, INVALID_HANDLE);
+    const FfiHandle invalid_handle(12345);
+    (void)invalid_handle;
   }
 
-  // Wait for the required logs to be forwarded
   {
     std::unique_lock<std::mutex> lock(mut);
-    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(1), required_rust_logs_received));
+    ASSERT_TRUE(cv.wait_for(lock, std::chrono::seconds(2), all_rust_logs_received));
   }
 
   if (print_logs) {
@@ -400,11 +398,12 @@ TEST_F(LoggingTest, RustLogsAreForwarded) {
     std::cout << "Error logs: " << error_log_count << '\n';
   }
 
-  EXPECT_GT(warn_log_count, 0);
   EXPECT_GT(debug_log_count, 0);
+  EXPECT_GT(info_log_count, 0);
+  EXPECT_GT(warn_log_count, 0);
   EXPECT_GT(error_log_count, 0);
 
-  livekit_ffi_dispose();
+  FfiClient::instance().shutdown();
 }
 
 TEST_F(LoggingTest, DummyRustTest) {

--- a/src/tests/unit/test_logging.cpp
+++ b/src/tests/unit/test_logging.cpp
@@ -70,10 +70,13 @@ struct LogRecord {
 
 class LoggingTest : public ::testing::Test {
 protected:
-  void SetUp() override { livekit::initialize(); }
+  void SetUp() override { livekit::setLogLevel(LogLevel::Info); }
 
   void TearDown() override {
     livekit::setLogCallback(nullptr);
+    if (FfiClient::instance().isInitialized()) {
+      FfiClient::instance().shutdown();
+    }
     livekit::shutdown();
   }
 };


### PR DESCRIPTION
This PR does the following:

- Forwards all Rust logs via FFI log event (forwards any log macro invocation from Rust code)
  - Critical note: `livekit::initialize(level, log_sink)` is deprecated as of this PR but is still backwards compatible. `log_sink` did not accurately change logging behavior, and `livekit::setLogCallback` is actually the only way. The FFI log API change is independent of callback behavior, but this PR also ensures logs from SDK or FFI layer work the same sink-wise. Overloaded this with `initialize(level)` and marked the other as deprecated
- Adds unit test
- Bumps Rust FFI submodule to recent release version for better log phrasing/behavior

<img width="1077" height="382" alt="Screenshot 2026-05-19 at 9 38 55 AM" src="https://github.com/user-attachments/assets/99554230-3088-442f-a1dd-c071121e40ec" />

Minor unrelated changes that happened along the way:
- Also implements `panic` event the same way Python does
- Hardened `AGENTS.md` language around format/tidy

## Testing

Added unit test to verify behavior across Error, Warn, Info and Debug levels (Trace not logged in Rust side).