### PR TITLE
Fix race in event_tracer/repeat unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -198,20 +198,22 @@ jobs:
       # ---------- Run unit tests ----------
       - name: Run unit tests (Unix)
         if: runner.os != 'Windows'
-        timeout-minutes: 15
+        timeout-minutes: 10
         shell: bash
         run: |
           build-release/bin/livekit_unit_tests \
-            --gtest_repeat=1000 \
+            --gtest_repeat=100 \
+            --gtest_brief=1 \
             --gtest_output=xml:build-release/unit-test-results.xml
 
       - name: Run unit tests (Windows)
         if: runner.os == 'Windows'
-        timeout-minutes: 15
+        timeout-minutes: 10
         shell: pwsh
         run: |
           build-release\bin\livekit_unit_tests.exe `
-            --gtest_repeat=1000 `
+            --gtest_repeat=100 `
+            --gtest_brief=1 `
             --gtest_output="xml:build-release\unit-test-results.xml"
 
       # ---------- Install + start livekit-server for integration tests ----------

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -198,18 +198,20 @@ jobs:
       # ---------- Run unit tests ----------
       - name: Run unit tests (Unix)
         if: runner.os != 'Windows'
-        timeout-minutes: 1
+        timeout-minutes: 15
         shell: bash
         run: |
           build-release/bin/livekit_unit_tests \
+            --gtest_repeat=1000 \
             --gtest_output=xml:build-release/unit-test-results.xml
 
       - name: Run unit tests (Windows)
         if: runner.os == 'Windows'
-        timeout-minutes: 1
+        timeout-minutes: 15
         shell: pwsh
         run: |
           build-release\bin\livekit_unit_tests.exe `
+            --gtest_repeat=1000 `
             --gtest_output="xml:build-release\unit-test-results.xml"
 
       # ---------- Install + start livekit-server for integration tests ----------

--- a/src/trace/event_tracer.cpp
+++ b/src/trace/event_tracer.cpp
@@ -408,8 +408,12 @@ void StopTracing() {
   // Disable tracing first to stop new events
   g_tracing_enabled.store(false, std::memory_order_release);
 
-  // Signal writer thread to shut down
-  g_shutdown_requested.store(true);
+  // Signal writer thread to shut down. The shutdown flag must be set while
+  // holding g_mutex so the writer thread cannot miss the notification
+  {
+    const std::scoped_lock<std::mutex> lock(g_mutex);
+    g_shutdown_requested.store(true);
+  }
   g_cv.notify_one();
 
   // Wait for writer thread to finish


### PR DESCRIPTION
Context: occasionally the CI runs would hang indefinitely on `EventTracer.*` based tests. This smelled like a race condition.

Root cause:

Race identified in `src/trace/event_tracer.cpp`. The writer thread waits on a CV under `g_mutex`:

```
std::unique_lock<std::mutex> lock(g_mutex);
g_cv.wait(lock, [] { return !g_event_queue.empty() || g_shutdown_requested.load(); });
```

But `StopTracing()` was modifying `g_shutdown_requested` without holding the `g_mutex`. 

```
g_shutdown_requested.store(true);   // outside the lock
g_cv.notify_one();
g_writer_thread.join();             // <-- blocks forever
```

Even though that individual variable is atomic, per the [CPP docs on condition variables](https://en.cppreference.com/cpp/thread/condition_variable):

> Even if the shared variable is atomic, it must be modified while owning the mutex to correctly publish the modification to the waiting thread.

Solution was to simply do just that in `StopTracing()`.


## Testing

Verified locally and in CI with 1000 repeats of all unit tests (single run prior). 

Also updated this stage to run all unit tests 100 times, but keep GTest output minimal to avoid spam.