### PR TITLE
Use LiveKit server GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
               - .github/workflows/ci.yml
               - .github/workflows/generate-docs.yml
               - .github/workflows/publish-docs.yml
-              - "!AGENTS.md"
             cpp_checks:
               - src/**
               - include/**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,7 +114,8 @@ jobs:
             libssl-dev \
             libprotobuf-dev protobuf-compiler \
             libabsl-dev \
-            libwayland-dev libdecor-0-dev
+            libwayland-dev libdecor-0-dev \
+            jq
 
       - name: Install deps (macOS)
         if: runner.os == 'macOS'
@@ -213,8 +214,19 @@ jobs:
         uses: livekit/dev-server-action@61e2b4dcb170dd3591e0c9b0db3c3fe5db93b500
         with:
           github-token: ${{ github.token }}
-          config: |
-            enable_data_tracks: true
+
+      # Needed by token helper script
+      - name: Install livekit-cli
+        if: matrix.e2e-testing
+        shell: bash
+        run: |
+          set -euxo pipefail
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            curl -sSL https://get.livekit.io/cli | bash
+          else
+            brew install livekit-cli
+          fi
+          lk --version
 
       - name: Run integration tests
         if: matrix.e2e-testing

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -114,15 +114,14 @@ jobs:
             libssl-dev \
             libprotobuf-dev protobuf-compiler \
             libabsl-dev \
-            libwayland-dev libdecor-0-dev \
-            jq
+            libwayland-dev libdecor-0-dev
 
       - name: Install deps (macOS)
         if: runner.os == 'macOS'
         run: |
           set -eux
           brew update
-          brew install cmake ninja protobuf abseil jq
+          brew install cmake ninja protobuf abseil
 
       # ---------- Rust toolchain ----------
       - name: Install Rust (stable)
@@ -207,47 +206,15 @@ jobs:
             --gtest_brief=1 `
             --gtest_output="xml:build-release\unit-test-results.xml"
 
-      # ---------- Install + start livekit-server for integration tests ----------
-      - name: Install livekit-server and lk CLI
-        if: matrix.e2e-testing
-        shell: bash
-        run: |
-          set -euxo pipefail
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
-            # Linux: official install scripts. lk's installer parses the GitHub
-            # API JSON with jq (already installed above).
-            curl -sSL https://get.livekit.io | bash
-            curl -sSL https://get.livekit.io/cli | bash
-          else
-            # macOS: Homebrew formulas. Server install script aborts on Darwin.
-            brew install livekit livekit-cli
-          fi
-          livekit-server --version
-          lk --version
-
+      # ---------- Start livekit-server for integration tests ----------
       - name: Start livekit-server
         if: matrix.e2e-testing
-        shell: bash
-        env:
-          LIVEKIT_CONFIG: "enable_data_tracks: true"
-        run: |
-          set -euxo pipefail
-          # Background the server with nohup so it survives this step's shell
-          # exit and remains running for the integration-test step.
-          nohup livekit-server --dev > livekit-server.log 2>&1 &
-          echo $! > livekit-server.pid
-          # Port 7880 is a WebSocket endpoint, so a TCP-connect probe is the
-          # most reliable readiness signal.
-          for _ in {1..30}; do
-            if nc -z 127.0.0.1 7880 >/dev/null 2>&1; then
-              echo "livekit-server is ready"
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "::error::livekit-server failed to start within 30s"
-          tail -n 200 livekit-server.log || true
-          exit 1
+        id: livekit_server
+        uses: livekit/dev-server-action@61e2b4dcb170dd3591e0c9b0db3c3fe5db93b500
+        with:
+          github-token: ${{ github.token }}
+          config: |
+            enable_data_tracks: true
 
       - name: Run integration tests
         if: matrix.e2e-testing
@@ -261,19 +228,10 @@ jobs:
           build-release/bin/livekit_integration_tests \
             --gtest_output=xml:build-release/integration-test-results.xml
 
-      - name: Stop livekit-server
-        if: always() && matrix.e2e-testing
-        shell: bash
-        run: |
-          if [ -f livekit-server.pid ]; then
-            kill "$(cat livekit-server.pid)" 2>/dev/null || true
-            rm -f livekit-server.pid
-          fi
-
       - name: Dump livekit-server log on failure
         if: failure() && matrix.e2e-testing
         shell: bash
-        run: tail -n 500 livekit-server.log || true
+        run: tail -n 500 "${{ steps.livekit_server.outputs.log-path }}" || true
 
       # ---------- Upload results ----------
       - name: Upload test results
@@ -284,7 +242,7 @@ jobs:
           path: |
             build-release/unit-test-results.xml
             build-release/integration-test-results.xml
-            livekit-server.log
+            ${{ steps.livekit_server.outputs.log-path }}
           if-no-files-found: ignore
           retention-days: 7
 


### PR DESCRIPTION
Refactors out old manually installation/running of LiveKit server for CI integration tests to use new `dev-server-action` instead: https://github.com/livekit/dev-server-action