### PR TITLE
Add remaining available RoomOptions fields

### DIFF
--- a/include/livekit/room.h
+++ b/include/livekit/room.h
@@ -76,8 +76,17 @@ struct RoomOptions {
   ///   - remote audio/video frames
   bool auto_subscribe = true;
 
-  /// Enable adaptive stream so the server optimizes subscribed video layers.
-  bool adaptive_stream = false;
+  /// Enable adaptive stream for subscribed video tracks.
+  ///
+  /// When enabled, the SDK tells the server it may adjust the video layers sent
+  /// to this client based on what the application is currently rendering. This
+  /// lets the server pause or downscale subscribed video that is off-screen,
+  /// hidden, or only needed at a smaller size, reducing downstream bandwidth and
+  /// decode work. This affects media received by this room; use @ref dynacast
+  /// to control how this client publishes layers to others.
+  ///
+  /// If unset, the Rust SDK default is used.
+  std::optional<bool> adaptive_stream;
 
   /// Enable dynacast (server sends optimal layers depending on subscribers).
   bool dynacast = false;
@@ -89,7 +98,9 @@ struct RoomOptions {
   std::optional<RtcConfig> rtc_config;
 
   /// Number of retries for the initial room join after the first attempt.
-  std::uint32_t join_retries = 3;
+  ///
+  /// If unset, the Rust SDK default is used.
+  std::optional<std::uint32_t> join_retries;
 
   /// Enable single peer connection mode. When true, uses one RTCPeerConnection
   /// for both publishing and subscribing instead of two separate connections.
@@ -97,7 +108,9 @@ struct RoomOptions {
   bool single_peer_connection = true;
 
   /// Timeout for each individual signal connection attempt.
-  std::chrono::milliseconds connect_timeout = std::chrono::seconds(5);
+  ///
+  /// If unset, the Rust SDK default is used.
+  std::optional<std::chrono::milliseconds> connect_timeout;
 };
 
 /// Represents a LiveKit room session.

--- a/include/livekit/room.h
+++ b/include/livekit/room.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <chrono>
+#include <cstdint>
 #include <future>
 #include <memory>
 #include <mutex>
@@ -74,19 +76,28 @@ struct RoomOptions {
   ///   - remote audio/video frames
   bool auto_subscribe = true;
 
+  /// Enable adaptive stream so the server optimizes subscribed video layers.
+  bool adaptive_stream = false;
+
   /// Enable dynacast (server sends optimal layers depending on subscribers).
   bool dynacast = false;
+
+  /// Optional end-to-end encryption settings.
+  std::optional<E2EEOptions> encryption;
+
+  /// Optional WebRTC configuration (ICE policy, servers, etc.)
+  std::optional<RtcConfig> rtc_config;
+
+  /// Number of retries for the initial room join after the first attempt.
+  std::uint32_t join_retries = 3;
 
   /// Enable single peer connection mode. When true, uses one RTCPeerConnection
   /// for both publishing and subscribing instead of two separate connections.
   /// Falls back to dual peer connection if the server doesn't support single PC.
   bool single_peer_connection = true;
 
-  /// Optional WebRTC configuration (ICE policy, servers, etc.)
-  std::optional<RtcConfig> rtc_config;
-
-  /// Optional end-to-end encryption settings.
-  std::optional<E2EEOptions> encryption;
+  /// Timeout for each individual signal connection attempt.
+  std::chrono::milliseconds connect_timeout = std::chrono::seconds(5);
 };
 
 /// Represents a LiveKit room session.

--- a/include/livekit/room.h
+++ b/include/livekit/room.h
@@ -74,6 +74,8 @@ struct RoomOptions {
   /// This is CRITICAL. Without auto_subscribe, you will never receive:
   ///   - `track_subscribed` events
   ///   - remote audio/video frames
+  ///
+  /// @see https://docs.livekit.io/transport/media/subscribe/#selective-subscription
   bool auto_subscribe = true;
 
   /// Enable adaptive stream for subscribed video tracks.
@@ -85,16 +87,24 @@ struct RoomOptions {
   /// decode work. This affects media received by this room; use @ref dynacast
   /// to control how this client publishes layers to others.
   ///
+  /// @see https://docs.livekit.io/transport/media/subscribe/#adaptive-stream
+  ///
   /// If unset, the Rust SDK default is used.
   std::optional<bool> adaptive_stream;
 
   /// Enable dynacast (server sends optimal layers depending on subscribers).
+  ///
+  /// @see https://docs.livekit.io/transport/media/publish/#dynacast
   bool dynacast = false;
 
   /// Optional end-to-end encryption settings.
+  ///
+  /// @see https://docs.livekit.io/transport/encryption/
   std::optional<E2EEOptions> encryption;
 
   /// Optional WebRTC configuration (ICE policy, servers, etc.)
+  ///
+  /// @see https://docs.livekit.io/intro/basics/connect/#connection-reliability
   std::optional<RtcConfig> rtc_config;
 
   /// Number of retries for the initial room join after the first attempt.

--- a/src/ffi_client.cpp
+++ b/src/ffi_client.cpp
@@ -18,6 +18,8 @@
 
 #include <cassert>
 #include <csignal>
+#include <string>
+#include <type_traits>
 
 #include "data_track.pb.h"
 #include "ffi.pb.h"
@@ -34,10 +36,26 @@
 namespace livekit {
 
 namespace {
+
 inline void logAndThrow(const std::string& error_msg) {
   LK_LOG_ERROR("LiveKit SDK Error: {}", error_msg);
   throw std::runtime_error(error_msg);
 }
+
+// Helper for debug logging of optional values
+const auto optional_to_string = [](const auto& value) -> std::string {
+  if (!value) {
+    return "<unset>";
+  }
+  using Value = std::decay_t<decltype(*value)>;
+  if constexpr (std::is_same_v<Value, bool>) {
+    return *value ? "true" : "false";
+  } else if constexpr (std::is_same_v<Value, std::chrono::milliseconds>) {
+    return std::to_string(value->count());
+  } else {
+    return std::to_string(*value);
+  }
+};
 
 Result<proto::OwnedDataTrackStream, SubscribeDataTrackError> subscribeDataTrackFailure(SubscribeDataTrackErrorCode code,
                                                                                        const std::string& message) {
@@ -334,8 +352,9 @@ std::future<proto::ConnectCallback> FfiClient::connectAsync(const std::string& u
   LK_LOG_DEBUG(
       "[FfiClient] connectAsync: auto_subscribe={}, adaptive_stream={}, dynacast={}, "
       "single_peer_connection={}, join_retries={}, connect_timeout_ms={}",
-      options.auto_subscribe, options.adaptive_stream, options.dynacast, options.single_peer_connection,
-      options.join_retries, options.connect_timeout.count());
+      options.auto_subscribe, optional_to_string(options.adaptive_stream), options.dynacast,
+      options.single_peer_connection, optional_to_string(options.join_retries),
+      optional_to_string(options.connect_timeout));
 
   try {
     const proto::FfiResponse resp = sendRequest(req);

--- a/src/ffi_client.cpp
+++ b/src/ffi_client.cpp
@@ -20,11 +20,9 @@
 #include <csignal>
 
 #include "data_track.pb.h"
-#include "e2ee.pb.h"
 #include "ffi.pb.h"
 #include "livekit/build.h"
 #include "livekit/data_track_error.h"
-#include "livekit/e2ee.h"
 #include "livekit/ffi_handle.h"
 #include "livekit/room.h"
 #include "livekit/rpc_error.h"
@@ -331,50 +329,13 @@ std::future<proto::ConnectCallback> FfiClient::connectAsync(const std::string& u
   connect->set_url(url);
   connect->set_token(token);
   connect->set_request_async_id(async_id);
-  auto* opts = connect->mutable_options();
-  opts->set_auto_subscribe(options.auto_subscribe);
-  opts->set_dynacast(options.dynacast);
-  opts->set_single_peer_connection(options.single_peer_connection);
+  connect->mutable_options()->CopyFrom(toProto(options));
 
   LK_LOG_DEBUG(
-      "[FfiClient] connectAsync: auto_subscribe={}, dynacast={}, "
-      "single_peer_connection={}",
-      options.auto_subscribe, options.dynacast, options.single_peer_connection);
-
-  // --- E2EE / encryption (optional) ---
-  if (options.encryption.has_value()) {
-    const E2EEOptions& e2ee = *options.encryption;
-    const auto& kpo = e2ee.key_provider_options;
-
-    auto* enc = opts->mutable_encryption();
-    enc->set_encryption_type(static_cast<proto::EncryptionType>(e2ee.encryption_type));
-    enc->mutable_key_provider_options()->CopyFrom(toProto(kpo));
-  }
-
-  // --- RTC configuration (optional) ---
-  if (options.rtc_config.has_value()) {
-    const RtcConfig& rc = *options.rtc_config;
-    auto* rtc = opts->mutable_rtc_config();
-
-    rtc->set_ice_transport_type(static_cast<proto::IceTransportType>(rc.ice_transport_type));
-    rtc->set_continual_gathering_policy(static_cast<proto::ContinualGatheringPolicy>(rc.continual_gathering_policy));
-
-    for (const IceServer& ice : rc.ice_servers) {
-      auto* s = rtc->add_ice_servers();
-
-      // proto: repeated string urls = 1
-      if (!ice.url.empty()) {
-        s->add_urls(ice.url);
-      }
-      if (!ice.username.empty()) {
-        s->set_username(ice.username);
-      }
-      if (!ice.credential.empty()) {
-        // proto: password = 3
-        s->set_password(ice.credential);
-      }
-    }
-  }
+      "[FfiClient] connectAsync: auto_subscribe={}, adaptive_stream={}, dynacast={}, "
+      "single_peer_connection={}, join_retries={}, connect_timeout_ms={}",
+      options.auto_subscribe, options.adaptive_stream, options.dynacast, options.single_peer_connection,
+      options.join_retries, options.connect_timeout.count());
 
   try {
     const proto::FfiResponse resp = sendRequest(req);

--- a/src/room_proto_converter.cpp
+++ b/src/room_proto_converter.cpp
@@ -406,7 +406,9 @@ proto::KeyProviderOptions toProto(const KeyProviderOptions& in) {
 proto::RoomOptions toProto(const RoomOptions& in) {
   proto::RoomOptions out;
   out.set_auto_subscribe(in.auto_subscribe);
-  out.set_adaptive_stream(in.adaptive_stream);
+  if (in.adaptive_stream) {
+    out.set_adaptive_stream(*in.adaptive_stream);
+  }
   out.set_dynacast(in.dynacast);
 
   if (in.encryption) {
@@ -435,9 +437,13 @@ proto::RoomOptions toProto(const RoomOptions& in) {
     }
   }
 
-  out.set_join_retries(in.join_retries);
+  if (in.join_retries) {
+    out.set_join_retries(*in.join_retries);
+  }
   out.set_single_peer_connection(in.single_peer_connection);
-  out.set_connect_timeout_ms(static_cast<std::uint64_t>(in.connect_timeout.count()));
+  if (in.connect_timeout) {
+    out.set_connect_timeout_ms(static_cast<std::uint64_t>(in.connect_timeout->count()));
+  }
   return out;
 }
 

--- a/src/room_proto_converter.cpp
+++ b/src/room_proto_converter.cpp
@@ -17,6 +17,7 @@
 #include "room_proto_converter.h"
 
 #include "livekit/data_stream.h"
+#include "livekit/room.h"
 #include "room.pb.h"
 
 namespace livekit {
@@ -399,6 +400,44 @@ proto::KeyProviderOptions toProto(const KeyProviderOptions& in) {
   out.set_failure_tolerance(in.failure_tolerance);
   out.set_key_ring_size(in.key_ring_size);
   out.set_key_derivation_function(static_cast<proto::KeyDerivationFunction>(in.key_derivation_function));
+  return out;
+}
+
+proto::RoomOptions toProto(const RoomOptions& in) {
+  proto::RoomOptions out;
+  out.set_auto_subscribe(in.auto_subscribe);
+  out.set_adaptive_stream(in.adaptive_stream);
+  out.set_dynacast(in.dynacast);
+
+  if (in.encryption) {
+    auto* encryption = out.mutable_encryption();
+    encryption->set_encryption_type(static_cast<proto::EncryptionType>(in.encryption->encryption_type));
+    encryption->mutable_key_provider_options()->CopyFrom(toProto(in.encryption->key_provider_options));
+  }
+
+  if (in.rtc_config) {
+    auto* rtc = out.mutable_rtc_config();
+    rtc->set_ice_transport_type(static_cast<proto::IceTransportType>(in.rtc_config->ice_transport_type));
+    rtc->set_continual_gathering_policy(
+        static_cast<proto::ContinualGatheringPolicy>(in.rtc_config->continual_gathering_policy));
+
+    for (const IceServer& ice : in.rtc_config->ice_servers) {
+      auto* server = rtc->add_ice_servers();
+      if (!ice.url.empty()) {
+        server->add_urls(ice.url);
+      }
+      if (!ice.username.empty()) {
+        server->set_username(ice.username);
+      }
+      if (!ice.credential.empty()) {
+        server->set_password(ice.credential);
+      }
+    }
+  }
+
+  out.set_join_retries(in.join_retries);
+  out.set_single_peer_connection(in.single_peer_connection);
+  out.set_connect_timeout_ms(static_cast<std::uint64_t>(in.connect_timeout.count()));
   return out;
 }
 

--- a/src/room_proto_converter.h
+++ b/src/room_proto_converter.h
@@ -29,6 +29,7 @@ namespace livekit {
 enum class RpcErrorCode;
 class RemoteParticipant;
 struct ByteStreamInfo;
+struct RoomOptions;
 struct TextStreamInfo;
 
 // --------- basic helper conversions ---------
@@ -73,6 +74,7 @@ LIVEKIT_INTERNAL_API RoomMovedEvent roomMovedFromProto(const proto::RoomInfo& in
 // --------- room options conversions ---------
 
 LIVEKIT_INTERNAL_API proto::KeyProviderOptions toProto(const KeyProviderOptions& in);
+LIVEKIT_INTERNAL_API proto::RoomOptions toProto(const RoomOptions& in);
 
 LIVEKIT_INTERNAL_API proto::AudioEncoding toProto(const AudioEncodingOptions& in);
 LIVEKIT_INTERNAL_API AudioEncodingOptions fromProto(const proto::AudioEncoding& in);

--- a/src/tests/common/test_common.h
+++ b/src/tests/common/test_common.h
@@ -33,7 +33,12 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
+
+#ifdef _WIN32
+#include <stdlib.h>
+#endif
 
 // Include benchmark utilities for trace file analysis
 #include "../benchmark/benchmark_utils.h"
@@ -114,6 +119,84 @@ struct TestConfig {
 struct TestRoomConnectionOptions {
   RoomOptions room_options;
   RoomDelegate* delegate = nullptr;
+};
+
+// =============================================================================
+// Environment Variable Helpers
+// =============================================================================
+
+/// RAII helper that captures an environment variable's value and restores it
+/// when the scope ends. Optionally sets a new value for the scope duration.
+///
+/// Example:
+///   ScopedEnv log_filter("RUST_LOG", "livekit=debug");
+///   livekit::initialize(...);
+class ScopedEnv {
+public:
+  /// Capture the current value of @p name without changing it.
+  explicit ScopedEnv(std::string name) : name_(std::move(name)) { capture(); }
+
+  /// Capture the current value of @p name and set it to @p value.
+  ScopedEnv(std::string name, std::string value) : name_(std::move(name)) {
+    capture();
+    set(std::move(value));
+  }
+
+  ScopedEnv(const ScopedEnv&) = delete;
+  ScopedEnv& operator=(const ScopedEnv&) = delete;
+
+  ~ScopedEnv() { reset(); }
+
+  /// Set @p name to @p value for the remainder of this scope.
+  void set(const std::string& value) {
+    setEnvVar(name_, value);
+    restored_ = false;
+  }
+
+  /// Restore @p name to its original captured value.
+  void reset() {
+    if (restored_) {
+      return;
+    }
+
+    if (had_value_) {
+      setEnvVar(name_, original_value_);
+    } else {
+      unsetEnvVar(name_);
+    }
+    restored_ = true;
+  }
+
+  const std::string& name() const noexcept { return name_; }
+
+private:
+  static void setEnvVar(const std::string& name, const std::string& value) {
+#ifdef _WIN32
+    _putenv_s(name.c_str(), value.c_str());
+#else
+    setenv(name.c_str(), value.c_str(), 1);
+#endif
+  }
+
+  static void unsetEnvVar(const std::string& name) {
+#ifdef _WIN32
+    _putenv_s(name.c_str(), nullptr);
+#else
+    unsetenv(name.c_str());
+#endif
+  }
+
+  void capture() {
+    if (const char* value = std::getenv(name_.c_str())) {
+      had_value_ = true;
+      original_value_ = value;
+    }
+  }
+
+  std::string name_;
+  bool had_value_ = false;
+  bool restored_ = true;
+  std::string original_value_;
 };
 
 // =============================================================================

--- a/src/tests/common/test_common.h
+++ b/src/tests/common/test_common.h
@@ -209,6 +209,18 @@ inline uint64_t getTimestampUs() {
       .count();
 }
 
+/// Count non-overlapping occurrences of @p target_str within @p source_str.
+/// @note This is mainly useful for counting occurrences in log statement captures
+inline std::size_t countOccurrences(const std::string& source_str, const std::string& target_str) {
+  std::size_t count = 0;
+  std::size_t pos = 0;
+  while ((pos = source_str.find(target_str, pos)) != std::string::npos) {
+    ++count;
+    pos += target_str.size();
+  }
+  return count;
+}
+
 /// Wait for a remote participant to appear in the room
 inline bool waitForParticipant(Room* room, const std::string& identity, std::chrono::milliseconds timeout) {
   auto start = std::chrono::steady_clock::now();

--- a/src/tests/common/test_common.h
+++ b/src/tests/common/test_common.h
@@ -33,12 +33,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
-#include <utility>
 #include <vector>
-
-#ifdef _WIN32
-#include <stdlib.h>
-#endif
 
 // Include benchmark utilities for trace file analysis
 #include "../benchmark/benchmark_utils.h"
@@ -122,84 +117,6 @@ struct TestRoomConnectionOptions {
 };
 
 // =============================================================================
-// Environment Variable Helpers
-// =============================================================================
-
-/// RAII helper that captures an environment variable's value and restores it
-/// when the scope ends. Optionally sets a new value for the scope duration.
-///
-/// Example:
-///   ScopedEnv log_filter("RUST_LOG", "livekit=debug");
-///   livekit::initialize(...);
-class ScopedEnv {
-public:
-  /// Capture the current value of @p name without changing it.
-  explicit ScopedEnv(std::string name) : name_(std::move(name)) { capture(); }
-
-  /// Capture the current value of @p name and set it to @p value.
-  ScopedEnv(std::string name, std::string value) : name_(std::move(name)) {
-    capture();
-    set(std::move(value));
-  }
-
-  ScopedEnv(const ScopedEnv&) = delete;
-  ScopedEnv& operator=(const ScopedEnv&) = delete;
-
-  ~ScopedEnv() { reset(); }
-
-  /// Set @p name to @p value for the remainder of this scope.
-  void set(const std::string& value) {
-    setEnvVar(name_, value);
-    restored_ = false;
-  }
-
-  /// Restore @p name to its original captured value.
-  void reset() {
-    if (restored_) {
-      return;
-    }
-
-    if (had_value_) {
-      setEnvVar(name_, original_value_);
-    } else {
-      unsetEnvVar(name_);
-    }
-    restored_ = true;
-  }
-
-  const std::string& name() const noexcept { return name_; }
-
-private:
-  static void setEnvVar(const std::string& name, const std::string& value) {
-#ifdef _WIN32
-    _putenv_s(name.c_str(), value.c_str());
-#else
-    setenv(name.c_str(), value.c_str(), 1);
-#endif
-  }
-
-  static void unsetEnvVar(const std::string& name) {
-#ifdef _WIN32
-    _putenv_s(name.c_str(), nullptr);
-#else
-    unsetenv(name.c_str());
-#endif
-  }
-
-  void capture() {
-    if (const char* value = std::getenv(name_.c_str())) {
-      had_value_ = true;
-      original_value_ = value;
-    }
-  }
-
-  std::string name_;
-  bool had_value_ = false;
-  bool restored_ = true;
-  std::string original_value_;
-};
-
-// =============================================================================
 // Utility Functions
 // =============================================================================
 
@@ -207,18 +124,6 @@ private:
 inline uint64_t getTimestampUs() {
   return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch())
       .count();
-}
-
-/// Count non-overlapping occurrences of @p target_str within @p source_str.
-/// @note This is mainly useful for counting occurrences in log statement captures
-inline std::size_t countOccurrences(const std::string& source_str, const std::string& target_str) {
-  std::size_t count = 0;
-  std::size_t pos = 0;
-  while ((pos = source_str.find(target_str, pos)) != std::string::npos) {
-    ++count;
-    pos += target_str.size();
-  }
-  return count;
 }
 
 /// Wait for a remote participant to appear in the room

--- a/src/tests/unit/test_room.cpp
+++ b/src/tests/unit/test_room.cpp
@@ -18,10 +18,10 @@
 #include <livekit/livekit.h>
 
 #include <chrono>
-#include <cstdlib>
 #include <iostream>
 #include <string>
 
+#include "../common/test_common.h"
 #include "room_proto_converter.h"
 
 namespace livekit::test {
@@ -30,20 +30,9 @@ namespace {
 
 constexpr const char* kRustRetryLogFilter = "livekit::rtc_engine=warn,livekit_ffi::server::room=error";
 
-void setRustLogForRetryTest() {
-#ifdef _WIN32
-  _putenv_s("RUST_LOG", kRustRetryLogFilter);
-#else
-  setenv("RUST_LOG", kRustRetryLogFilter, 1);
-#endif
-}
-
 // Configure RUST_LOG during static initialization, before any test can initialize
 // the Rust FFI logger (which reads env vars once at construction time).
-const bool kRustLogConfiguredBeforeTests = [] {
-  setRustLogForRetryTest();
-  return true;
-}();
+const ScopedEnv kRustLogEnv("RUST_LOG", kRustRetryLogFilter);
 
 std::size_t countOccurrences(const std::string& haystack, const std::string& needle) {
   std::size_t count = 0;
@@ -59,10 +48,7 @@ std::size_t countOccurrences(const std::string& haystack, const std::string& nee
 
 class RoomTest : public ::testing::Test {
 protected:
-  void SetUp() override {
-    setRustLogForRetryTest();
-    livekit::initialize(livekit::LogLevel::Info);
-  }
+  void SetUp() override { livekit::initialize(livekit::LogLevel::Info); }
 
   void TearDown() override { livekit::shutdown(); }
 };

--- a/src/tests/unit/test_room.cpp
+++ b/src/tests/unit/test_room.cpp
@@ -18,14 +18,42 @@
 #include <livekit/livekit.h>
 
 #include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <string>
 
 #include "room_proto_converter.h"
 
 namespace livekit::test {
 
+namespace {
+
+void setRustLogForRetryTest() {
+#ifdef _WIN32
+  _putenv_s("RUST_LOG", "warn");
+#else
+  setenv("RUST_LOG", "warn", 1);
+#endif
+}
+
+std::size_t countOccurrences(const std::string& haystack, const std::string& needle) {
+  std::size_t count = 0;
+  std::size_t pos = 0;
+  while ((pos = haystack.find(needle, pos)) != std::string::npos) {
+    ++count;
+    pos += needle.size();
+  }
+  return count;
+}
+
+} // namespace
+
 class RoomTest : public ::testing::Test {
 protected:
-  void SetUp() override { livekit::initialize(livekit::LogLevel::Info); }
+  void SetUp() override {
+    setRustLogForRetryTest();
+    livekit::initialize(livekit::LogLevel::Info);
+  }
 
   void TearDown() override { livekit::shutdown(); }
 };
@@ -35,6 +63,8 @@ TEST_F(RoomTest, ConnectWithoutInitialize) {
   livekit::shutdown();
 
   Room room;
+
+  // Default room options okay here, will return before FFI layer since not initialized
   bool result = room.connect("wss://localhost:7880", "test", livekit::RoomOptions());
   EXPECT_FALSE(result) << "Connecting without initializing should return false";
   EXPECT_TRUE(room.localParticipant().expired()) << "Local participant should be empty after failed connect";
@@ -121,6 +151,36 @@ TEST_F(RoomTest, RoomOptionsProtoConverter) {
   EXPECT_FALSE(proto_options.single_peer_connection());
   EXPECT_TRUE(proto_options.has_connect_timeout_ms());
   EXPECT_EQ(proto_options.connect_timeout_ms(), 750U);
+}
+
+// This test validates the join retries behavior when connecting to an invalid URL
+// It sets the RUST_LOG env variable to capture the retry logs
+TEST_F(RoomTest, RoomOptionsJoinRetries) {
+  constexpr std::uint32_t kJoinRetries = 10;
+
+  Room room;
+  RoomOptions options;
+  options.join_retries = kJoinRetries;
+
+  testing::internal::CaptureStderr();
+  const bool result = room.connect("not-a-livekit-url", "test-token", options);
+  const std::string stderr_output = testing::internal::GetCapturedStderr();
+
+  EXPECT_FALSE(result) << "Connecting with an invalid URL should fail";
+  EXPECT_TRUE(room.localParticipant().expired()) << "Local participant should be empty after failed connect";
+  EXPECT_TRUE(room.remoteParticipants().empty()) << "Remote participants should be empty after failed connect";
+
+  // Do the below that way we can print stderr only once if there was a string change to the output
+  const bool has_failure = HasFailure();
+
+  EXPECT_NE(stderr_output.find("Room::connect failed:"), std::string::npos);
+  EXPECT_EQ(countOccurrences(stderr_output, "retrying..."), kJoinRetries);
+  EXPECT_NE(stderr_output.find("retrying... (10/10)"), std::string::npos);
+
+  if (!has_failure && HasFailure()) {
+    std::cerr << "### One or more checks failed due to log format changing. Captured stderr output below ###\n";
+    std::cerr << stderr_output << "\n";
+  }
 }
 
 TEST_F(RoomTest, RtcConfigDefaults) {

--- a/src/tests/unit/test_room.cpp
+++ b/src/tests/unit/test_room.cpp
@@ -34,16 +34,6 @@ constexpr const char* kRustRetryLogFilter = "livekit::rtc_engine=warn,livekit_ff
 // the Rust FFI logger (which reads env vars once at construction time).
 const ScopedEnv kRustLogEnv("RUST_LOG", kRustRetryLogFilter);
 
-std::size_t countOccurrences(const std::string& haystack, const std::string& needle) {
-  std::size_t count = 0;
-  std::size_t pos = 0;
-  while ((pos = haystack.find(needle, pos)) != std::string::npos) {
-    ++count;
-    pos += needle.size();
-  }
-  return count;
-}
-
 } // namespace
 
 class RoomTest : public ::testing::Test {

--- a/src/tests/unit/test_room.cpp
+++ b/src/tests/unit/test_room.cpp
@@ -51,13 +51,13 @@ TEST_F(RoomTest, RoomOptionsDefaults) {
   RoomOptions options;
 
   EXPECT_TRUE(options.auto_subscribe) << "auto_subscribe should default to true";
-  EXPECT_FALSE(options.adaptive_stream) << "adaptive_stream should default to false";
+  EXPECT_FALSE(options.adaptive_stream.has_value()) << "adaptive_stream should defer to Rust default";
   EXPECT_FALSE(options.dynacast) << "dynacast should default to false";
   EXPECT_FALSE(options.encryption.has_value()) << "encryption should not have a value by default";
   EXPECT_FALSE(options.rtc_config.has_value()) << "rtc_config should not have a value by default";
-  EXPECT_EQ(options.join_retries, 3U) << "join_retries should default to Rust SDK behavior";
+  EXPECT_FALSE(options.join_retries.has_value()) << "join_retries should defer to Rust default";
   EXPECT_TRUE(options.single_peer_connection) << "single_peer_connection should default to true";
-  EXPECT_EQ(options.connect_timeout, std::chrono::seconds(5)) << "connect_timeout should default to Rust SDK behavior";
+  EXPECT_FALSE(options.connect_timeout.has_value()) << "connect_timeout should defer to Rust default";
 }
 
 TEST_F(RoomTest, RoomOptionsToProtoSerializesDefaults) {
@@ -65,18 +65,15 @@ TEST_F(RoomTest, RoomOptionsToProtoSerializesDefaults) {
 
   EXPECT_TRUE(proto_options.has_auto_subscribe());
   EXPECT_TRUE(proto_options.auto_subscribe());
-  EXPECT_TRUE(proto_options.has_adaptive_stream());
-  EXPECT_FALSE(proto_options.adaptive_stream());
+  EXPECT_FALSE(proto_options.has_adaptive_stream());
   EXPECT_TRUE(proto_options.has_dynacast());
   EXPECT_FALSE(proto_options.dynacast());
   EXPECT_FALSE(proto_options.has_encryption());
   EXPECT_FALSE(proto_options.has_rtc_config());
-  EXPECT_TRUE(proto_options.has_join_retries());
-  EXPECT_EQ(proto_options.join_retries(), 3U);
+  EXPECT_FALSE(proto_options.has_join_retries());
   EXPECT_TRUE(proto_options.has_single_peer_connection());
   EXPECT_TRUE(proto_options.single_peer_connection());
-  EXPECT_TRUE(proto_options.has_connect_timeout_ms());
-  EXPECT_EQ(proto_options.connect_timeout_ms(), 5000U);
+  EXPECT_FALSE(proto_options.has_connect_timeout_ms());
 }
 
 TEST_F(RoomTest, RoomOptionsProtoConverter) {

--- a/src/tests/unit/test_room.cpp
+++ b/src/tests/unit/test_room.cpp
@@ -17,6 +17,10 @@
 #include <gtest/gtest.h>
 #include <livekit/livekit.h>
 
+#include <chrono>
+
+#include "room_proto_converter.h"
+
 namespace livekit::test {
 
 class RoomTest : public ::testing::Test {
@@ -47,9 +51,79 @@ TEST_F(RoomTest, RoomOptionsDefaults) {
   RoomOptions options;
 
   EXPECT_TRUE(options.auto_subscribe) << "auto_subscribe should default to true";
+  EXPECT_FALSE(options.adaptive_stream) << "adaptive_stream should default to false";
   EXPECT_FALSE(options.dynacast) << "dynacast should default to false";
-  EXPECT_FALSE(options.rtc_config.has_value()) << "rtc_config should not have a value by default";
   EXPECT_FALSE(options.encryption.has_value()) << "encryption should not have a value by default";
+  EXPECT_FALSE(options.rtc_config.has_value()) << "rtc_config should not have a value by default";
+  EXPECT_EQ(options.join_retries, 3U) << "join_retries should default to Rust SDK behavior";
+  EXPECT_TRUE(options.single_peer_connection) << "single_peer_connection should default to true";
+  EXPECT_EQ(options.connect_timeout, std::chrono::seconds(5)) << "connect_timeout should default to Rust SDK behavior";
+}
+
+TEST_F(RoomTest, RoomOptionsToProtoSerializesDefaults) {
+  const proto::RoomOptions proto_options = toProto(RoomOptions{});
+
+  EXPECT_TRUE(proto_options.has_auto_subscribe());
+  EXPECT_TRUE(proto_options.auto_subscribe());
+  EXPECT_TRUE(proto_options.has_adaptive_stream());
+  EXPECT_FALSE(proto_options.adaptive_stream());
+  EXPECT_TRUE(proto_options.has_dynacast());
+  EXPECT_FALSE(proto_options.dynacast());
+  EXPECT_FALSE(proto_options.has_encryption());
+  EXPECT_FALSE(proto_options.has_rtc_config());
+  EXPECT_TRUE(proto_options.has_join_retries());
+  EXPECT_EQ(proto_options.join_retries(), 3U);
+  EXPECT_TRUE(proto_options.has_single_peer_connection());
+  EXPECT_TRUE(proto_options.single_peer_connection());
+  EXPECT_TRUE(proto_options.has_connect_timeout_ms());
+  EXPECT_EQ(proto_options.connect_timeout_ms(), 5000U);
+}
+
+TEST_F(RoomTest, RoomOptionsProtoConverter) {
+  RoomOptions options;
+  options.auto_subscribe = false;
+  options.adaptive_stream = true;
+  options.dynacast = true;
+  E2EEOptions encryption;
+  encryption.key_provider_options.shared_key = std::vector<std::uint8_t>{'s', 'e', 'c', 'r', 'e', 't'};
+  options.encryption = encryption;
+  RtcConfig rtc_config;
+  rtc_config.ice_transport_type = proto::TRANSPORT_ALL;
+  rtc_config.continual_gathering_policy = proto::GATHER_CONTINUALLY;
+  rtc_config.ice_servers.push_back({"stun:stun.l.google.com:19302", "", ""});
+  rtc_config.ice_servers.push_back({"turn:turn.example.com:3478", "user", "pass"});
+  options.rtc_config = rtc_config;
+  options.join_retries = 8;
+  options.single_peer_connection = false;
+  options.connect_timeout = std::chrono::milliseconds(750);
+
+  const proto::RoomOptions proto_options = toProto(options);
+
+  EXPECT_TRUE(proto_options.has_auto_subscribe());
+  EXPECT_FALSE(proto_options.auto_subscribe());
+  EXPECT_TRUE(proto_options.has_adaptive_stream());
+  EXPECT_TRUE(proto_options.adaptive_stream());
+  EXPECT_TRUE(proto_options.has_dynacast());
+  EXPECT_TRUE(proto_options.dynacast());
+  ASSERT_TRUE(proto_options.has_encryption());
+  EXPECT_EQ(proto_options.encryption().encryption_type(),
+            static_cast<proto::EncryptionType>(encryption.encryption_type));
+  ASSERT_TRUE(proto_options.encryption().has_key_provider_options());
+  EXPECT_EQ(proto_options.encryption().key_provider_options().shared_key(), "secret");
+  ASSERT_TRUE(proto_options.has_rtc_config());
+  EXPECT_EQ(proto_options.rtc_config().ice_transport_type(), proto::TRANSPORT_ALL);
+  EXPECT_EQ(proto_options.rtc_config().continual_gathering_policy(), proto::GATHER_CONTINUALLY);
+  ASSERT_EQ(proto_options.rtc_config().ice_servers_size(), 2);
+  EXPECT_EQ(proto_options.rtc_config().ice_servers(0).urls(0), "stun:stun.l.google.com:19302");
+  EXPECT_EQ(proto_options.rtc_config().ice_servers(1).urls(0), "turn:turn.example.com:3478");
+  EXPECT_EQ(proto_options.rtc_config().ice_servers(1).username(), "user");
+  EXPECT_EQ(proto_options.rtc_config().ice_servers(1).password(), "pass");
+  EXPECT_TRUE(proto_options.has_join_retries());
+  EXPECT_EQ(proto_options.join_retries(), 8U);
+  EXPECT_TRUE(proto_options.has_single_peer_connection());
+  EXPECT_FALSE(proto_options.single_peer_connection());
+  EXPECT_TRUE(proto_options.has_connect_timeout_ms());
+  EXPECT_EQ(proto_options.connect_timeout_ms(), 750U);
 }
 
 TEST_F(RoomTest, RtcConfigDefaults) {

--- a/src/tests/unit/test_room.cpp
+++ b/src/tests/unit/test_room.cpp
@@ -18,23 +18,12 @@
 #include <livekit/livekit.h>
 
 #include <chrono>
-#include <iostream>
 #include <string>
 
-#include "../common/test_common.h"
+#include "ffi.pb.h"
 #include "room_proto_converter.h"
 
 namespace livekit::test {
-
-namespace {
-
-constexpr const char* kRustRetryLogFilter = "livekit::rtc_engine=warn,livekit_ffi::server::room=error";
-
-// Configure RUST_LOG during static initialization, before any test can initialize
-// the Rust FFI logger (which reads env vars once at construction time).
-const ScopedEnv kRustLogEnv("RUST_LOG", kRustRetryLogFilter);
-
-} // namespace
 
 class RoomTest : public ::testing::Test {
 protected:
@@ -138,34 +127,32 @@ TEST_F(RoomTest, RoomOptionsProtoConverter) {
   EXPECT_EQ(proto_options.connect_timeout_ms(), 750U);
 }
 
-// This test validates the join retries behavior when connecting to an invalid URL
-// It sets the RUST_LOG env variable to capture the retry logs
-TEST_F(RoomTest, RoomOptionsJoinRetries) {
-  constexpr std::uint32_t kJoinRetries = 10;
-
-  Room room;
+TEST(RoomOptionsProtoTest, ConnectRequestSerializesRetryOptions) {
   RoomOptions options;
-  options.join_retries = kJoinRetries;
+  options.join_retries = 8;
+  options.connect_timeout = std::chrono::milliseconds(750);
 
-  testing::internal::CaptureStderr();
-  const bool result = room.connect("not-a-livekit-url", "test-token", options);
-  const std::string stderr_output = testing::internal::GetCapturedStderr();
+  proto::FfiRequest request;
+  auto* connect = request.mutable_connect();
+  connect->set_url("ws://localhost:7880");
+  connect->set_token("test-token");
+  connect->mutable_options()->CopyFrom(toProto(options));
 
-  EXPECT_FALSE(result) << "Connecting with an invalid URL should fail";
-  EXPECT_TRUE(room.localParticipant().expired()) << "Local participant should be empty after failed connect";
-  EXPECT_TRUE(room.remoteParticipants().empty()) << "Remote participants should be empty after failed connect";
+  ASSERT_TRUE(connect->options().has_join_retries());
+  EXPECT_EQ(connect->options().join_retries(), 8U);
+  ASSERT_TRUE(connect->options().has_connect_timeout_ms());
+  EXPECT_EQ(connect->options().connect_timeout_ms(), 750U);
 
-  // Do the below that way we can print stderr only once if there was a string change to the output
-  const bool has_failure = HasFailure();
+  ASSERT_TRUE(request.IsInitialized()) << request.InitializationErrorString();
 
-  EXPECT_NE(stderr_output.find("Room::connect failed:"), std::string::npos);
-  EXPECT_EQ(countOccurrences(stderr_output, "retrying..."), kJoinRetries);
-  EXPECT_NE(stderr_output.find("retrying... (10/10)"), std::string::npos);
+  std::string serialized;
+  ASSERT_TRUE(request.SerializeToString(&serialized));
+  EXPECT_FALSE(serialized.empty());
 
-  if (!has_failure && HasFailure()) {
-    std::cerr << "### One or more checks failed due to log format changing. Captured stderr output below ###\n";
-    std::cerr << stderr_output << "\n";
-  }
+  proto::FfiRequest decoded;
+  ASSERT_TRUE(decoded.ParseFromString(serialized));
+  EXPECT_EQ(decoded.connect().options().join_retries(), 8U);
+  EXPECT_EQ(decoded.connect().options().connect_timeout_ms(), 750U);
 }
 
 TEST_F(RoomTest, RtcConfigDefaults) {

--- a/src/tests/unit/test_room.cpp
+++ b/src/tests/unit/test_room.cpp
@@ -28,13 +28,22 @@ namespace livekit::test {
 
 namespace {
 
+constexpr const char* kRustRetryLogFilter = "livekit::rtc_engine=warn,livekit_ffi::server::room=error";
+
 void setRustLogForRetryTest() {
 #ifdef _WIN32
-  _putenv_s("RUST_LOG", "warn");
+  _putenv_s("RUST_LOG", kRustRetryLogFilter);
 #else
-  setenv("RUST_LOG", "warn", 1);
+  setenv("RUST_LOG", kRustRetryLogFilter, 1);
 #endif
 }
+
+// Configure RUST_LOG during static initialization, before any test can initialize
+// the Rust FFI logger (which reads env vars once at construction time).
+const bool kRustLogConfiguredBeforeTests = [] {
+  setRustLogForRetryTest();
+  return true;
+}();
 
 std::size_t countOccurrences(const std::string& haystack, const std::string& needle) {
   std::size_t count = 0;


### PR DESCRIPTION
- Adds support for missing room options (`RoomOptions` struct)
- Remove adhoc logic to serialize certain room options into the FFI; now just has a `toProto` helper for the entire struct
- Unit tests