### PR TITLE
chore: update rust-sdks to livekit-ffi v0.12.68

### DIFF
--- a/include/livekit/room_event_types.h
+++ b/include/livekit/room_event_types.h
@@ -277,9 +277,9 @@ struct AudioEncodingOptions {
 enum class DegradationPreference {
   /// Balance between framerate and resolution degradation.
   Balanced = 0,
-  /// Degrade framerate to maintain resolution.
+  /// Degrade resolution to maintain framerate (prioritize smooth motion).
   MaintainFramerate = 1,
-  /// Degrade resolution to maintain framerate (drop frames to keep clarity).
+  /// Degrade framerate to maintain resolution (prioritize image clarity).
   MaintainResolution = 2,
   /// Maintain both framerate and resolution. Frames may be dropped before
   /// encoding if necessary to avoid overusing network and encoder resources.

--- a/include/livekit/room_event_types.h
+++ b/include/livekit/room_event_types.h
@@ -273,6 +273,19 @@ struct AudioEncodingOptions {
   std::uint64_t max_bitrate = 0;
 };
 
+/// Controls how the encoder degrades quality when bandwidth is constrained.
+enum class DegradationPreference {
+  /// Balance between framerate and resolution degradation.
+  Balanced = 0,
+  /// Degrade framerate to maintain resolution.
+  MaintainFramerate = 1,
+  /// Degrade resolution to maintain framerate (drop frames to keep clarity).
+  MaintainResolution = 2,
+  /// Maintain both framerate and resolution. Frames may be dropped before
+  /// encoding if necessary to avoid overusing network and encoder resources.
+  MaintainFramerateAndResolution = 4,
+};
+
 /// Optional RTP packet-trailer features for published video tracks.
 struct PacketTrailerFeatures {
   /// Embed a user-supplied wall-clock timestamp.
@@ -313,6 +326,10 @@ struct TrackPublishOptions {
 
   /// Optional packet-trailer features to enable for published video.
   PacketTrailerFeatures packet_trailer_features{};
+
+  /// Controls how the encoder trades off between resolution and framerate
+  /// when bandwidth is constrained. Default is MaintainResolution.
+  std::optional<DegradationPreference> degradation_preference;
 };
 
 // ---------------------------------------------------------

--- a/src/room_proto_converter.cpp
+++ b/src/room_proto_converter.cpp
@@ -505,6 +505,9 @@ proto::TrackPublishOptions toProto(const TrackPublishOptions& in) {
   for (const proto::PacketTrailerFeature feature : toProto(in.packet_trailer_features)) {
     msg.add_packet_trailer_features(feature);
   }
+  if (in.degradation_preference) {
+    msg.set_degradation_preference(static_cast<proto::DegradationPreference>(*in.degradation_preference));
+  }
   return msg;
 }
 
@@ -538,6 +541,9 @@ TrackPublishOptions fromProto(const proto::TrackPublishOptions& in) {
     out.preconnect_buffer = in.preconnect_buffer();
   }
   out.packet_trailer_features = fromProto(in.packet_trailer_features());
+  if (in.has_degradation_preference()) {
+    out.degradation_preference = static_cast<DegradationPreference>(in.degradation_preference());
+  }
   return out;
 }
 


### PR DESCRIPTION
## Summary

Updates rust-sdks submodule to livekit-ffi v0.12.68.

## Changes

- Add `MaintainFramerateAndResolution` to `DegradationPreference` enum (aligns with WebRTC M144)
- `DISABLED` is deprecated, use `MAINTAIN_FRAMERATE_AND_RESOLUTION` instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)