### PR TITLE
feat: support cross-compilation (tested for 32-bit ARM Linux)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,10 @@ configure_file(
 find_program(CARGO_EXECUTABLE NAMES cargo REQUIRED)
 
 # Determine Rust target triple for cross-compilation on macOS
-set(RUST_TARGET_TRIPLE "")
+# (may also be pre-set by a cross toolchain file, e.g. cross/toolchain-ameba-armv7.cmake)
+if(NOT DEFINED RUST_TARGET_TRIPLE)
+  set(RUST_TARGET_TRIPLE "")
+endif()
 if(APPLE AND CMAKE_OSX_ARCHITECTURES)
   if(CMAKE_OSX_ARCHITECTURES STREQUAL "x86_64")
     set(RUST_TARGET_TRIPLE "x86_64-apple-darwin")
@@ -256,7 +259,7 @@ if(NOT DEFINED CARGO)
   message(FATAL_ERROR \"CARGO not set\")
 endif()
 
-set(ARGS build)
+set(ARGS build -p livekit-ffi)
 if(NOT CFG STREQUAL \"Debug\")
   list(APPEND ARGS --release)
 endif()

--- a/cmake/protobuf.cmake
+++ b/cmake/protobuf.cmake
@@ -149,7 +149,19 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON CACHE BOOL "" FORCE)
 set(protobuf_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(protobuf_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 set(protobuf_BUILD_CONFORMANCE OFF CACHE BOOL "" FORCE)
-set(protobuf_BUILD_PROTOC_BINARIES ON CACHE BOOL "" FORCE)
+if(CMAKE_CROSSCOMPILING)
+  # protoc must run on the build host, so don't cross-compile it; a host
+  # protoc matching LIVEKIT_PROTOBUF_VERSION must be provided instead via
+  # -DProtobuf_PROTOC_EXECUTABLE.
+  set(protobuf_BUILD_PROTOC_BINARIES OFF CACHE BOOL "" FORCE)
+  if(NOT Protobuf_PROTOC_EXECUTABLE)
+    message(FATAL_ERROR
+      "Cross-compiling: pass -DProtobuf_PROTOC_EXECUTABLE=<host protoc "
+      "v${LIVEKIT_PROTOBUF_VERSION} binary>")
+  endif()
+else()
+  set(protobuf_BUILD_PROTOC_BINARIES ON CACHE BOOL "" FORCE)
+endif()
 set(protobuf_WITH_ZLIB OFF CACHE BOOL "" FORCE)
 
 set(protobuf_ABSL_PROVIDER "package" CACHE STRING "" FORCE)
@@ -198,12 +210,16 @@ foreach(_livekit_protobuf_target IN LISTS _livekit_protobuf_targets)
 endforeach()
 
 # Protobuf targets: modern protobuf exports protobuf::protoc etc.
-if(TARGET protobuf::protoc)
-  set(Protobuf_PROTOC_EXECUTABLE "$<TARGET_FILE:protobuf::protoc>" CACHE STRING "protoc (vendored)" FORCE)
-elseif(TARGET protoc)
-  set(Protobuf_PROTOC_EXECUTABLE "$<TARGET_FILE:protoc>" CACHE STRING "protoc (vendored)" FORCE)
-else()
-  message(FATAL_ERROR "Vendored protobuf did not create a protoc target")
+# When cross-compiling, protoc binaries are not built; the host protoc
+# supplied via Protobuf_PROTOC_EXECUTABLE is used as-is.
+if(NOT CMAKE_CROSSCOMPILING)
+  if(TARGET protobuf::protoc)
+    set(Protobuf_PROTOC_EXECUTABLE "$<TARGET_FILE:protobuf::protoc>" CACHE STRING "protoc (vendored)" FORCE)
+  elseif(TARGET protoc)
+    set(Protobuf_PROTOC_EXECUTABLE "$<TARGET_FILE:protoc>" CACHE STRING "protoc (vendored)" FORCE)
+  else()
+    message(FATAL_ERROR "Vendored protobuf did not create a protoc target")
+  endif()
 endif()
 
 # Prefer protobuf-lite (optional; keep libprotobuf around too)


### PR DESCRIPTION
## What

Makes the C++ SDK buildable with a CMake cross toolchain file. Verified end-to-end for **32-bit ARM Linux** (`armv7-unknown-linux-gnueabihf`) targeting an embedded armv8 AArch32 (Cortex-A32, glibc 2.39) sysroot: `liblivekit.so` + `liblivekit_ffi.so` build, and `livekit::initialize()`/`shutdown()` round-trips through the FFI under qemu-arm.

Companion PR (Rust side / libwebrtc arm build): livekit/rust-sdks#1218

## Changes

- **Honor a pre-set `RUST_TARGET_TRIPLE`**: a cross toolchain file can now set it (cache var), and the cargo build gets `--target` plus the imported `liblivekit_ffi.so` path follows `target/<triple>/`. Previously the triple was only derived on macOS.
- **Scope cargo to `-p livekit-ffi`**: the workspace has no `default-members`, so plain `cargo build` also compiled all examples (including wgpu-based ones) — wasted work natively, build failures when cross-compiling.
- **Cross-aware protoc**: `cmake/protobuf.cmake` force-enabled `protobuf_BUILD_PROTOC_BINARIES`, producing a target-arch protoc that cannot run on the build host ("Exec format error" at codegen). When `CMAKE_CROSSCOMPILING`, protoc binaries are now skipped and a host protoc matching the vendored protobuf version must be passed via `-DProtobuf_PROTOC_EXECUTABLE` (official release binaries work). It is forwarded to the Rust build via `ENV{PROTOC}` as before.

## Usage example

```cmake
# toolchain-arm.cmake
set(CMAKE_SYSTEM_NAME Linux)
set(CMAKE_SYSTEM_PROCESSOR arm)
set(CMAKE_SYSROOT /path/to/target-sysroot)
set(CMAKE_C_COMPILER   arm-...-gcc)
set(CMAKE_CXX_COMPILER arm-...-g++)
set(RUST_TARGET_TRIPLE armv7-unknown-linux-gnueabihf CACHE STRING "" FORCE)
```

```sh
cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_TOOLCHAIN_FILE=toolchain-arm.cmake \
  -DProtobuf_PROTOC_EXECUTABLE=/path/to/host/protoc   # v25.3
cmake --build build
```

(plus the usual cargo cross setup: `rustup target add`, linker in `.cargo/config.toml`, and `LK_CUSTOM_WEBRTC` pointing at a libwebrtc built with `build_linux.sh --arch arm` from the rust-sdks PR.)

No behavior change for native builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L4fDRyTiTphQnidL2Myptq
