### PR TITLE
Bugfix: AudioFrame input sanitization

### DIFF
--- a/include/livekit/audio_frame.h
+++ b/include/livekit/audio_frame.h
@@ -45,8 +45,7 @@ public:
   ///
   /// @throws std::invalid_argument if @p num_channels or
   ///         @p samples_per_channel is not positive, or if the data size is
-  ///         inconsistent with num_channels * samples_per_channel, or if that
-  ///         product cannot be represented by std::size_t.
+  ///         inconsistent with num_channels * samples_per_channel.
   AudioFrame(std::vector<std::int16_t> data, int sample_rate, int num_channels, int samples_per_channel);
   AudioFrame(); // Default constructor
   virtual ~AudioFrame() = default;

--- a/include/livekit/audio_frame.h
+++ b/include/livekit/audio_frame.h
@@ -43,8 +43,10 @@ public:
   /// @param num_channels        Number of channels.
   /// @param samples_per_channel Number of samples per channel.
   ///
-  /// @throws std::invalid_argument if the data size is inconsistent with
-  ///         num_channels * samples_per_channel.
+  /// @throws std::invalid_argument if @p num_channels or
+  ///         @p samples_per_channel is not positive, or if the data size is
+  ///         inconsistent with num_channels * samples_per_channel, or if that
+  ///         product cannot be represented by std::size_t.
   AudioFrame(std::vector<std::int16_t> data, int sample_rate, int num_channels, int samples_per_channel);
   AudioFrame(); // Default constructor
   virtual ~AudioFrame() = default;

--- a/src/audio_frame.cpp
+++ b/src/audio_frame.cpp
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <iomanip>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 
@@ -35,7 +36,16 @@ AudioFrame::AudioFrame(std::vector<std::int16_t> data, int sample_rate, int num_
       sample_rate_(sample_rate),
       num_channels_(num_channels),
       samples_per_channel_(samples_per_channel) {
-  const std::size_t expected = static_cast<std::size_t>(num_channels_) * static_cast<std::size_t>(samples_per_channel_);
+  if (num_channels_ <= 0 || samples_per_channel_ <= 0) {
+    throw std::invalid_argument("AudioFrame: num_channels and samples_per_channel must be positive");
+  }
+
+  const auto channels = static_cast<std::size_t>(num_channels_);
+  const auto samples = static_cast<std::size_t>(samples_per_channel_);
+  if (channels > std::numeric_limits<std::size_t>::max() / samples) {
+    throw std::invalid_argument("AudioFrame: num_channels * samples_per_channel overflows");
+  }
+  const std::size_t expected = channels * samples;
 
   if (data_.size() < expected) {
     throw std::invalid_argument("AudioFrame: data size must be >= num_channels * samples_per_channel");

--- a/src/audio_frame.cpp
+++ b/src/audio_frame.cpp
@@ -19,7 +19,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <iomanip>
-#include <limits>
 #include <sstream>
 #include <stdexcept>
 
@@ -42,9 +41,6 @@ AudioFrame::AudioFrame(std::vector<std::int16_t> data, int sample_rate, int num_
 
   const auto channels = static_cast<std::size_t>(num_channels_);
   const auto samples = static_cast<std::size_t>(samples_per_channel_);
-  if (channels > std::numeric_limits<std::size_t>::max() / samples) {
-    throw std::invalid_argument("AudioFrame: num_channels * samples_per_channel overflows");
-  }
   const std::size_t expected = channels * samples;
 
   if (data_.size() < expected) {

--- a/src/tests/unit/test_audio_frame.cpp
+++ b/src/tests/unit/test_audio_frame.cpp
@@ -163,4 +163,13 @@ TEST_F(AudioFrameTest, InvalidDataSizeThrows) {
   EXPECT_THROW(AudioFrame(data, 48000, 2, 960), std::invalid_argument);
 }
 
+TEST_F(AudioFrameTest, NonPositiveDimensionsThrow) {
+  const std::vector<std::int16_t> data;
+
+  EXPECT_THROW(AudioFrame(data, 48000, 0, 960), std::invalid_argument);
+  EXPECT_THROW(AudioFrame(data, 48000, 2, 0), std::invalid_argument);
+  EXPECT_THROW(AudioFrame(data, 48000, -1, 960), std::invalid_argument);
+  EXPECT_THROW(AudioFrame(data, 48000, 2, -1), std::invalid_argument);
+}
+
 } // namespace livekit::test


### PR DESCRIPTION
`AudioFrame` constructor was not fully input sanitized, leading to potential issues with division by 0 or integer overflows later in the class.