### PR TITLE
Temporarily disable platform audio integration tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -275,6 +275,8 @@ jobs:
           set -euo pipefail
           source .token_helpers/set_data_track_test_tokens.bash
           build-release/bin/livekit_integration_tests \
+            # Temporarily disable platform audio integration tests in CI until instability is resolved
+            --gtest_filter='-PlatformAudioIntegrationTest.*' \
             --gtest_output=xml:build-release/integration-test-results.xml
 
       - name: Dump livekit-server log on failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -275,7 +275,7 @@ jobs:
           set -euo pipefail
           source .token_helpers/set_data_track_test_tokens.bash
           build-release/bin/livekit_integration_tests \
-            # Temporarily disable platform audio integration tests in CI until instability is resolved
+            # TODO(BOT-477) Temporarily disable platform audio integration tests in CI until instability is resolved
             --gtest_filter='-PlatformAudioIntegrationTest.*' \
             --gtest_output=xml:build-release/integration-test-results.xml
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -274,8 +274,8 @@ jobs:
         run: |
           set -euo pipefail
           source .token_helpers/set_data_track_test_tokens.bash
+          # TODO(BOT-477) Temporarily disable platform audio integration tests in CI until instability is resolved
           build-release/bin/livekit_integration_tests \
-            # TODO(BOT-477) Temporarily disable platform audio integration tests in CI until instability is resolved
             --gtest_filter='-PlatformAudioIntegrationTest.*' \
             --gtest_output=xml:build-release/integration-test-results.xml
 


### PR DESCRIPTION
Disables platform audio integration tests in CI until instability can be isolated and fixed. Has been exposing larger runtime/state/ownership issues in the Rust SDK which are not resolved. Seems to be crashing unrelated tests frequently.