### PR TITLE
Only build Rust livekit-ffi crate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ if(NOT DEFINED CARGO)
   message(FATAL_ERROR \"CARGO not set\")
 endif()
 
-set(ARGS build)
+set(ARGS build --package livekit-ffi)
 if(NOT CFG STREQUAL \"Debug\")
   list(APPEND ARGS --release)
 endif()


### PR DESCRIPTION
@ladvoc noted that this SDK was building all of Rust when only the `livekit-ffi` crate is actually used. This resolves that.