### PR TITLE
Build explicit Ubuntu versions, add Ubuntu 22.04 support

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -33,11 +33,19 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            name: linux-x64
+            name: ubuntu-22.04-x64
             build_cmd: ./build.sh release-examples
             build_dir: build-release
           - os: ubuntu-22.04-arm
-            name: linux-arm64
+            name: ubuntu-22.04-arm64
+            build_cmd: ./build.sh release-examples
+            build_dir: build-release
+          - os: ubuntu-24.04
+            name: ubuntu-24.04-x64
+            build_cmd: ./build.sh release-examples
+            build_dir: build-release
+          - os: ubuntu-24.04-arm
+            name: ubuntu-24.04-arm64
             build_cmd: ./build.sh release-examples
             build_dir: build-release
           - os: macos-26-xlarge
@@ -327,6 +335,28 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: livekit-sdk-${{ matrix.name }}
+          path: |
+            ${{ matrix.build_dir }}/lib/
+            ${{ matrix.build_dir }}/include/
+            ${{ matrix.build_dir }}/bin/
+          retention-days: 7
+
+      - name: Upload deprecated linux-x64 alias artifact
+        if: matrix.name == 'ubuntu-24.04-x64'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: livekit-sdk-linux-x64
+          path: |
+            ${{ matrix.build_dir }}/lib/
+            ${{ matrix.build_dir }}/include/
+            ${{ matrix.build_dir }}/bin/
+          retention-days: 7
+
+      - name: Upload deprecated linux-arm64 alias artifact
+        if: matrix.name == 'ubuntu-24.04-arm64'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: livekit-sdk-linux-arm64
           path: |
             ${{ matrix.build_dir }}/lib/
             ${{ matrix.build_dir }}/include/

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -169,11 +169,6 @@ jobs:
       # step that runs AFTER the "Clean after build" cleanup wipes target/debug
       # and target/release, which is why the old cache was always ~empty. The
       # restore/save split lets us snapshot the populated target/ before cleanup.
-      #
-      # Key on matrix.os (runner image), not runner.os. runner.os is just
-      # "Linux" for both ubuntu-22.04 and ubuntu-24.04, and restored
-      # build-scripts / .so files from a newer glibc host fail with
-      # GLIBC_2.39 not found on the older image.
       - name: Restore cargo target
         id: cache-cargo-target
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -161,14 +161,19 @@ jobs:
       # step that runs AFTER the "Clean after build" cleanup wipes target/debug
       # and target/release, which is why the old cache was always ~empty. The
       # restore/save split lets us snapshot the populated target/ before cleanup.
+      #
+      # Key on matrix.os (runner image), not runner.os. runner.os is just
+      # "Linux" for both ubuntu-22.04 and ubuntu-24.04, and restored
+      # build-scripts / .so files from a newer glibc host fail with
+      # GLIBC_2.39 not found on the older image.
       - name: Restore cargo target
         id: cache-cargo-target
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: client-sdk-rust/target/
-          key: ${{ runner.os }}-${{ matrix.name }}-cargo-target-${{ steps.rust_sha.outputs.sha }}
+          key: ${{ matrix.os }}-${{ matrix.name }}-cargo-target-${{ steps.rust_sha.outputs.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.name }}-cargo-target-
+            ${{ matrix.os }}-${{ matrix.name }}-cargo-target-
 
       # restore-keys can hydrate target/ from a prior submodule SHA. cxxbridge
       # artifacts in webrtc-sys are not compatible across those bumps.
@@ -208,7 +213,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: client-sdk-rust/target/
-          key: ${{ runner.os }}-${{ matrix.name }}-cargo-target-${{ steps.rust_sha.outputs.sha }}
+          key: ${{ matrix.os }}-${{ matrix.name }}-cargo-target-${{ steps.rust_sha.outputs.sha }}
 
       - name: Save vcpkg binary cache
         if: runner.os == 'Windows' && steps.cache-vcpkg-binary.outputs.cache-hit != 'true'

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -32,11 +32,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             name: linux-x64
             build_cmd: ./build.sh release-examples
             build_dir: build-release
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-22.04-arm
             name: linux-arm64
             build_cmd: ./build.sh release-examples
             build_dir: build-release

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -464,17 +464,6 @@ jobs:
           name: v${{ steps.version.outputs.version }}
           draft: true
           files: ${{ github.workspace }}/release-assets/*
-          body: |
-            ## Linux assets
-
-            Prefer the explicit Ubuntu assets:
-
-            - `livekit-sdk-ubuntu-22.04-x64`
-            - `livekit-sdk-ubuntu-22.04-arm64`
-            - `livekit-sdk-ubuntu-24.04-x64`
-            - `livekit-sdk-ubuntu-24.04-arm64`
-
-            `livekit-sdk-linux-x64` and `livekit-sdk-linux-arm64` are deprecated aliases of the Ubuntu 24.04 builds and will be removed in a future release.
           generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -25,10 +25,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            name: linux-x64
+            name: ubuntu-22.04-x64
             generator: Ninja
           - os: ubuntu-22.04-arm
-            name: linux-arm64
+            name: ubuntu-22.04-arm64
+            generator: Ninja
+          - os: ubuntu-24.04
+            name: ubuntu-24.04-x64
+            generator: Ninja
+          - os: ubuntu-24.04-arm
+            name: ubuntu-24.04-arm64
             generator: Ninja
           - os: macos-26-xlarge
             name: macos-arm64
@@ -416,8 +422,8 @@ jobs:
           echo "Artifacts downloaded:"
           ls -la
           
-          # Create tar.gz for Linux and macOS
-          for platform in linux-x64 linux-arm64 macos-arm64 macos-x64; do
+          # Create tar.gz for Ubuntu and macOS
+          for platform in ubuntu-22.04-x64 ubuntu-22.04-arm64 ubuntu-24.04-x64 ubuntu-24.04-arm64 macos-arm64 macos-x64; do
             dirName="livekit-sdk-${platform}-${VERSION}"
             if [[ -d "${dirName}" ]]; then
               echo "Creating archive for ${platform}..."
@@ -425,6 +431,12 @@ jobs:
               echo "Created: ${dirName}.tar.gz"
             fi
           done
+
+          # Deprecated compatibility aliases for existing Linux release consumers.
+          cp "${{ github.workspace }}/release-assets/livekit-sdk-ubuntu-24.04-x64-${VERSION}.tar.gz" \
+             "${{ github.workspace }}/release-assets/livekit-sdk-linux-x64-${VERSION}.tar.gz"
+          cp "${{ github.workspace }}/release-assets/livekit-sdk-ubuntu-24.04-arm64-${VERSION}.tar.gz" \
+             "${{ github.workspace }}/release-assets/livekit-sdk-linux-arm64-${VERSION}.tar.gz"
           
           # Create zip for Windows
           dirName="livekit-sdk-windows-x64-${VERSION}"
@@ -444,6 +456,17 @@ jobs:
           name: v${{ steps.version.outputs.version }}
           draft: true
           files: ${{ github.workspace }}/release-assets/*
+          body: |
+            ## Linux assets
+
+            Prefer the explicit Ubuntu assets:
+
+            - `livekit-sdk-ubuntu-22.04-x64`
+            - `livekit-sdk-ubuntu-22.04-arm64`
+            - `livekit-sdk-ubuntu-24.04-x64`
+            - `livekit-sdk-ubuntu-24.04-arm64`
+
+            `livekit-sdk-linux-x64` and `livekit-sdk-linux-arm64` are deprecated aliases of the Ubuntu 24.04 builds and will be removed in a future release.
           generate_release_notes: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -24,10 +24,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             name: linux-x64
             generator: Ninja
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-22.04-arm
             name: linux-arm64
             generator: Ninja
           - os: macos-26-xlarge

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -157,14 +157,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.name }}-cargo-registry-
 
+      # Key on matrix.os (runner image), not runner.os — see builds.yml.
+      # Compiled target/ artifacts are glibc-bound and must not restore across
+      # Ubuntu major versions (e.g. 24.04 → 22.04 → GLIBC_2.39 not found).
       - name: Cache cargo target
         id: cache-cargo-target
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: client-sdk-rust/target/
-          key: ${{ runner.os }}-${{ matrix.name }}-cargo-target-${{ steps.rust_sha.outputs.sha }}
+          key: ${{ matrix.os }}-${{ matrix.name }}-cargo-target-${{ steps.rust_sha.outputs.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.name }}-cargo-target-
+            ${{ matrix.os }}-${{ matrix.name }}-cargo-target-
 
       # restore-keys can hydrate target/ from a prior submodule SHA. cxxbridge
       # artifacts in webrtc-sys are not compatible across those bumps.

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -433,10 +433,19 @@ jobs:
           done
 
           # Deprecated compatibility aliases for existing Linux release consumers.
-          cp "${{ github.workspace }}/release-assets/livekit-sdk-ubuntu-24.04-x64-${VERSION}.tar.gz" \
-             "${{ github.workspace }}/release-assets/livekit-sdk-linux-x64-${VERSION}.tar.gz"
-          cp "${{ github.workspace }}/release-assets/livekit-sdk-ubuntu-24.04-arm64-${VERSION}.tar.gz" \
-             "${{ github.workspace }}/release-assets/livekit-sdk-linux-arm64-${VERSION}.tar.gz"
+          # Repack the Ubuntu 24.04 artifacts so their extracted directory
+          # retains the legacy Linux name.
+          for pair in "ubuntu-24.04-x64:linux-x64" "ubuntu-24.04-arm64:linux-arm64"; do
+            src="livekit-sdk-${pair%%:*}-${VERSION}"
+            dst="livekit-sdk-${pair#*:}-${VERSION}"
+            if [[ -d "${src}" ]]; then
+              cp -R "${src}" "${dst}"
+              tar -czf "${{ github.workspace }}/release-assets/${dst}.tar.gz" "${dst}"
+              echo "Created compatibility archive: ${dst}.tar.gz"
+            else
+              echo "WARNING: Skipping compatibility archive; ${src} was not downloaded."
+            fi
+          done
           
           # Create zip for Windows
           dirName="livekit-sdk-windows-x64-${VERSION}"

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -163,7 +163,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.name }}-cargo-registry-
 
-      # Key on matrix.os (runner image), not runner.os — see builds.yml.
       # Compiled target/ artifacts are glibc-bound and must not restore across
       # Ubuntu major versions (e.g. 24.04 → 22.04 → GLIBC_2.39 not found).
       - name: Cache cargo target

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -261,14 +261,17 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.name }}-cargo-registry-
 
+      # Key on matrix.os (runner image), not runner.os — see builds.yml.
+      # Compiled target/ artifacts are glibc-bound and must not restore across
+      # Ubuntu major versions (e.g. 24.04 → 22.04 → GLIBC_2.39 not found).
       - name: Restore cargo target
         id: cache-cargo-target
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: client-sdk-rust/target/
-          key: ${{ runner.os }}-${{ matrix.name }}-cargo-target-${{ steps.rust_sha.outputs.sha }}
+          key: ${{ matrix.os }}-${{ matrix.name }}-cargo-target-${{ steps.rust_sha.outputs.sha }}
           restore-keys: |
-            ${{ runner.os }}-${{ matrix.name }}-cargo-target-
+            ${{ matrix.os }}-${{ matrix.name }}-cargo-target-
 
       # restore-keys can hydrate target/ from a prior submodule SHA. cxxbridge
       # artifacts in webrtc-sys are not compatible across those bumps.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -267,7 +267,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.name }}-cargo-registry-
 
-      # Key on matrix.os (runner image), not runner.os — see builds.yml.
       # Compiled target/ artifacts are glibc-bound and must not restore across
       # Ubuntu major versions (e.g. 24.04 → 22.04 → GLIBC_2.39 not found).
       - name: Restore cargo target

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -139,10 +139,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             name: linux-x64
             e2e-testing: true
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-22.04-arm
             name: linux-arm64
             e2e-testing: true
           - os: macos-26-xlarge

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,10 +140,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
-            name: linux-x64
+            name: ubuntu-22.04-x64
             e2e-testing: true
           - os: ubuntu-22.04-arm
-            name: linux-arm64
+            name: ubuntu-22.04-arm64
+            e2e-testing: true
+          - os: ubuntu-24.04
+            name: ubuntu-24.04-x64
+            e2e-testing: true
+          - os: ubuntu-24.04-arm
+            name: ubuntu-24.04-arm64
             e2e-testing: true
           - os: macos-26-xlarge
             name: macos-arm64


### PR DESCRIPTION
## Summary

Adjust Linux release to build against explicit Ubuntu 22.04 and 24.04 runners instead of `ubuntu-latest`, and publish explicit release artifacts:

New: `livekit-sdk-ubuntu-22.04-{x64,arm64}` and `livekit-sdk-ubuntu-24.04-{x64,arm64}`
Deprecated (kept for backwards compatibility): `livekit-sdk-linux-{x64,arm64}` (simply repackaged from the existing Ubuntu 24.04 builds)

Also fixes Rust `target/` cache keys to use matrix.os rather than runner.os, so 24.04-compiled artifacts are not restored on 22.04 runners (which caused GLIBC_2.39 failures). Tests and builds now run on both Ubuntu versions.

## Testing

- Verified in ROS Portal branch against release candidate
- Verified in C++ Example collection against old deprecated "linux" repackaged artifact

## Context

In [ROS Portal](https://github.com/livekit/ros-portal), ROS Humble targets Ubuntu 22.04, and the "linux" LiveKit SDK targets 24.04. The glibc version for 24.04 was not backwards compat on 22.04, but the 22.04 glibc is forwards compatible in 24.04. Thus, we were incurring 30+min SDK build times in ROS Portal CI to rebuild the LiveKit SDK against 22.04. 

Therefore in ROS Portal, all LiveKit SDK links will be against 22.04 based artifacts, but will work in 22.04, 24.04, and 26.04 Ubuntu runtime versions for the respective distros.

This approach is also what FoxGlove takes for their SDK/ROS bridge equivalent. [Link](https://github.com/foxglove/foxglove-sdk/blob/main/.github/workflows/draft-ros-release.yml#L23-L24)