### PR TITLE
Use robotics team CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Specify default code owners for all files with a wildcard:
+* @livekit/robotics-devs @xianshijing-lk

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# Specify a default Code Owner for all files with a wildcard:
-* @alan-george-lk @stephen-derosa @xianshijing-lk


### PR DESCRIPTION
- Moves `CODEOWNERS` out of root into `.github/` folder
- Uses [robotics-devs](https://github.com/orgs/livekit/teams/robotics-devs) as default approvers plus existing owner