### PR TITLE
FFI version 0.12.76, clang compatibility changes

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -125,6 +125,14 @@ jobs:
             libcurl4-openssl-dev \
             libwayland-dev libdecor-0-dev
 
+      # The libwebrtc artifact ships a hermetic libc++ built from LLVM trunk.
+      # Distro clang (14 on Ubuntu 22.04, 18 on 24.04) cannot compile its
+      # headers; the submodule script installs LLVM 21 and exports CC/CXX.
+      - name: Install clang for libwebrtc
+        if: runner.os == 'Linux'
+        shell: bash
+        run: client-sdk-rust/.github/scripts/install-clang.sh
+
       - name: Install deps (macOS)
         if: runner.os == 'macOS'
         run: |

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -199,8 +199,9 @@ jobs:
         run: |
           echo "CXXFLAGS=-Wno-deprecated-declarations" >> "$GITHUB_ENV"
           echo "CFLAGS=-Wno-deprecated-declarations" >> "$GITHUB_ENV"
-          LLVM_VERSION=$(llvm-config --version | cut -d. -f1)
-          echo "LIBCLANG_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib" >> "$GITHUB_ENV"
+          LLVM_ROOT="$(dirname "${CXX}")/.."
+          test -f "${LLVM_ROOT}/lib/libclang.so"
+          echo "LIBCLANG_PATH=${LLVM_ROOT}/lib" >> "$GITHUB_ENV"
 
       # ---------- Build ----------
       - name: Build (Unix)

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -125,6 +125,14 @@ jobs:
             libcurl4-openssl-dev \
             libwayland-dev libdecor-0-dev
 
+      # The libwebrtc artifact ships a hermetic libc++ built from LLVM trunk.
+      # Distro clang cannot compile its headers; install the same LLVM version
+      # used by the Linux build and test workflows.
+      - name: Install clang for libwebrtc
+        if: runner.os == 'Linux'
+        shell: bash
+        run: client-sdk-rust/.github/scripts/install-clang.sh
+
       - name: Install deps (macOS)
         if: runner.os == 'macOS'
         run: |
@@ -185,10 +193,11 @@ jobs:
       - name: Set Linux build environment
         if: runner.os == 'Linux'
         run: |
-          echo "CXXFLAGS=-Wno-deprecated-declarations" >> $GITHUB_ENV
-          echo "CFLAGS=-Wno-deprecated-declarations" >> $GITHUB_ENV
-          LLVM_VERSION=$(llvm-config --version | cut -d. -f1)
-          echo "LIBCLANG_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib" >> $GITHUB_ENV
+          echo "CXXFLAGS=-Wno-deprecated-declarations" >> "$GITHUB_ENV"
+          echo "CFLAGS=-Wno-deprecated-declarations" >> "$GITHUB_ENV"
+          LLVM_ROOT="$(dirname "${CXX}")/.."
+          test -f "${LLVM_ROOT}/lib/libclang.so"
+          echo "LIBCLANG_PATH=${LLVM_ROOT}/lib" >> "$GITHUB_ENV"
 
       # ---------- Build + Bundle (Unix) ----------
       - name: Build and Bundle (Unix)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -299,8 +299,9 @@ jobs:
         run: |
           echo "CXXFLAGS=-Wno-deprecated-declarations" >> "$GITHUB_ENV"
           echo "CFLAGS=-Wno-deprecated-declarations" >> "$GITHUB_ENV"
-          LLVM_VERSION=$(llvm-config --version | cut -d. -f1)
-          echo "LIBCLANG_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib" >> "$GITHUB_ENV"
+          LLVM_ROOT="$(dirname "${CXX}")/.."
+          test -f "${LLVM_ROOT}/lib/libclang.so"
+          echo "LIBCLANG_PATH=${LLVM_ROOT}/lib" >> "$GITHUB_ENV"
 
       - name: Configure Unix crash diagnostics
         if: runner.os != 'Windows'
@@ -558,10 +559,11 @@ jobs:
       # ---------- Build environment setup ----------
       - name: Set build environment
         run: |
-          LLVM_VERSION=$(llvm-config --version | cut -d. -f1)
-          echo "LIBCLANG_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib" >> "$GITHUB_ENV"
-          LLVM_COV="$(dirname "${CXX}")/llvm-cov"
+          LLVM_ROOT="$(dirname "${CXX}")/.."
+          test -f "${LLVM_ROOT}/lib/libclang.so"
+          LLVM_COV="${LLVM_ROOT}/bin/llvm-cov"
           test -x "${LLVM_COV}"
+          echo "LIBCLANG_PATH=${LLVM_ROOT}/lib" >> "$GITHUB_ENV"
           echo "GCOV_EXECUTABLE=${LLVM_COV} gcov" >> "$GITHUB_ENV"
 
       # ---------- Configure with upstream preset + coverage flag overrides ----------

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,6 +229,14 @@ jobs:
             libwayland-dev libdecor-0-dev \
             gdb jq
 
+      # The libwebrtc artifact ships a hermetic libc++ built from LLVM trunk.
+      # Distro clang (14 on Ubuntu 22.04, 18 on 24.04) cannot compile its
+      # headers; the submodule script installs LLVM 21 and exports CC/CXX.
+      - name: Install clang for libwebrtc
+        if: runner.os == 'Linux'
+        shell: bash
+        run: client-sdk-rust/.github/scripts/install-clang.sh
+
       - name: Install deps (macOS)
         if: runner.os == 'macOS'
         run: |
@@ -511,6 +519,12 @@ jobs:
             libwayland-dev libdecor-0-dev
           pip install --break-system-packages gcovr
 
+      # The coverage build compiles the Rust FFI too, so it needs the same
+      # compiler floor as the normal Linux build/test matrices.
+      - name: Install clang for libwebrtc
+        shell: bash
+        run: client-sdk-rust/.github/scripts/install-clang.sh
+
       # ---------- Rust toolchain ----------
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772
@@ -546,8 +560,9 @@ jobs:
         run: |
           LLVM_VERSION=$(llvm-config --version | cut -d. -f1)
           echo "LIBCLANG_PATH=/usr/lib/llvm-${LLVM_VERSION}/lib" >> "$GITHUB_ENV"
-          GCC_VER=$(gcc -dumpversion | cut -d. -f1)
-          echo "GCOV_EXECUTABLE=gcov-${GCC_VER}" >> "$GITHUB_ENV"
+          LLVM_COV="$(dirname "${CXX}")/llvm-cov"
+          test -x "${LLVM_COV}"
+          echo "GCOV_EXECUTABLE=${LLVM_COV} gcov" >> "$GITHUB_ENV"
 
       # ---------- Configure with upstream preset + coverage flag overrides ----------
       - name: Configure (linux-debug-tests preset + coverage flags)


### PR DESCRIPTION
- Updates to [livekit-ffi 0.12.76](https://github.com/livekit/rust-sdks/releases/tag/livekit-ffi%2Fv0.12.76), bringing in:
  - Upgrades libwebrtc to M150
  - More reliable TURN/TLS conne ctions via OS trust-store fallback
  - Automatic retry for WebRTC build downloads
  - WARP transport features enabled by default when supported by the server
  - Token handling moved into a dedicated crate, with fixes for service-only feature builds
- Fixes some `clang` compatibility issues the upstream introduced as part of `libwebrtc` version change