### PR TITLE
Various Cuda/FFI Memory Lifecycle Fixes

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -10,3 +10,7 @@ https://livekit.io/join-slack
 https://livekit.com/join-slack
 https://join.slack.com/*
 https://livekit-users.slack.com/*
+https://x.com/livekit
+https://x.com/*
+https://twitter.com/livekit
+https://twitter.com/*


### PR DESCRIPTION
Pulls in [livekit-ffi/v0.12.77](https://github.com/livekit/rust-sdks/releases/tag/livekit-ffi%2Fv0.12.77), fixing the following issues:

- Room disconnect closes peer connections before signal teardown, so cancelled close can no longer leak ICE UDP sockets
- Repeated connect/disconnect no longer retains room sessions or data-channel observer cycles
- Dropping an unused VideoSource now releases its keepalive buffers instead of pinning them for the process lifetime
NVIDIA encoder/decoder factories tear down a shared CUDA context on last drop, and NVENC init failures no longer leave a half-initialized encoder
- FFI shutdown drops leftover handles one at a time so nested dispose cannot re-enter handle-map clear
- PlatformAudio runs all ADM access on the WebRTC worker thread, creates the ADM lazily, and keeps Android recording and shutdown races from dropping audio
- Linux dmabuf frames are captured through the existing video capture path
- Publishing pre-encoded video on macOS no longer segfaults